### PR TITLE
Add GitHub issue sync preparation

### DIFF
--- a/crates/api-types/src/issue_comment.rs
+++ b/crates/api-types/src/issue_comment.rs
@@ -16,7 +16,7 @@ pub struct IssueComment {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Deserialize, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct CreateIssueCommentRequest {
     /// Optional client-generated ID. If not provided, server generates one.
     /// Using client-generated IDs enables stable optimistic updates.
@@ -40,7 +40,7 @@ pub struct ListIssueCommentsQuery {
     pub issue_id: Uuid,
 }
 
-#[derive(Debug, Clone, Serialize, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct ListIssueCommentsResponse {
     pub issue_comments: Vec<IssueComment>,
 }

--- a/crates/server/src/routes/remote/issue_comments.rs
+++ b/crates/server/src/routes/remote/issue_comments.rs
@@ -1,0 +1,38 @@
+use api_types::{
+    CreateIssueCommentRequest, IssueComment, ListIssueCommentsQuery, ListIssueCommentsResponse,
+    MutationResponse,
+};
+use axum::{
+    Router,
+    extract::{Json, Query, State},
+    response::Json as ResponseJson,
+    routing::get,
+};
+use utils::response::ApiResponse;
+
+use crate::{DeploymentImpl, error::ApiError};
+
+pub(super) fn router() -> Router<DeploymentImpl> {
+    Router::new().route(
+        "/issue-comments",
+        get(list_issue_comments).post(create_issue_comment),
+    )
+}
+
+async fn list_issue_comments(
+    State(deployment): State<DeploymentImpl>,
+    Query(query): Query<ListIssueCommentsQuery>,
+) -> Result<ResponseJson<ApiResponse<ListIssueCommentsResponse>>, ApiError> {
+    let client = deployment.remote_client()?;
+    let response = client.list_issue_comments(query.issue_id).await?;
+    Ok(ResponseJson(ApiResponse::success(response)))
+}
+
+async fn create_issue_comment(
+    State(deployment): State<DeploymentImpl>,
+    Json(request): Json<CreateIssueCommentRequest>,
+) -> Result<ResponseJson<ApiResponse<MutationResponse<IssueComment>>>, ApiError> {
+    let client = deployment.remote_client()?;
+    let response = client.create_issue_comment(&request).await?;
+    Ok(ResponseJson(ApiResponse::success(response)))
+}

--- a/crates/server/src/routes/remote/mod.rs
+++ b/crates/server/src/routes/remote/mod.rs
@@ -3,6 +3,7 @@ use axum::Router;
 use crate::DeploymentImpl;
 
 mod issue_assignees;
+mod issue_comments;
 mod issue_relationships;
 mod issue_tags;
 mod issues;
@@ -15,6 +16,7 @@ mod workspaces;
 pub fn router() -> Router<DeploymentImpl> {
     Router::new()
         .merge(issue_assignees::router())
+        .merge(issue_comments::router())
         .merge(issue_relationships::router())
         .merge(issue_tags::router())
         .merge(issues::router())

--- a/crates/services/src/services/github_sync_plan.rs
+++ b/crates/services/src/services/github_sync_plan.rs
@@ -1,8 +1,9 @@
-/// Opt-in GitHub → Vibe Kanban sync planning.
+/// Opt-in GitHub → Vibe Kanban sync planning and execution.
 ///
-/// This module is deliberately side-effect-free: it takes a snapshot of GitHub issue
-/// data and the existing Kanban state, then produces a [`SyncPlan`] describing what
-/// mutations *would* need to happen. Callers decide whether/how to execute those ops.
+/// Planning is deliberately side-effect-free: it takes a snapshot of GitHub issue
+/// data and the existing Kanban state, then produces a [`SyncPlan`] describing the
+/// mutations needed. Callers can prepare those ops into remote API requests and pass
+/// them to [`execute_prepared_sync`] to apply the supported Kanban mutations.
 ///
 /// Tracking issue: gavinanelson/implication#171
 ///
@@ -15,8 +16,11 @@ use api_types::{
     CreateIssueCommentRequest, CreateIssueRelationshipRequest, CreateIssueRequest,
     IssueRelationshipType as ApiIssueRelationshipType, UpdateIssueRequest,
 };
+use async_trait::async_trait;
 use serde_json::json;
 use uuid::Uuid;
+
+use super::remote_client::{RemoteClient, RemoteClientError};
 
 // ---------------------------------------------------------------------------
 // GitHub-side types (populated from GitHub REST/GraphQL responses)
@@ -247,6 +251,72 @@ pub enum PreparedSyncAction {
 #[derive(Debug, Clone, Default)]
 pub struct PreparedSync {
     pub actions: Vec<PreparedSyncAction>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ExecutedSyncSummary {
+    pub created_issues: usize,
+    pub updated_issues: usize,
+    pub created_relationships: usize,
+    pub created_comments: usize,
+    pub skipped_unsupported: usize,
+}
+
+#[async_trait]
+pub trait PreparedSyncExecutor {
+    type Error;
+
+    async fn create_issue(&self, request: &CreateIssueRequest) -> Result<(), Self::Error>;
+    async fn update_issue(
+        &self,
+        issue_id: Uuid,
+        request: &UpdateIssueRequest,
+    ) -> Result<(), Self::Error>;
+    async fn create_issue_relationship(
+        &self,
+        request: &CreateIssueRelationshipRequest,
+    ) -> Result<(), Self::Error>;
+    async fn create_issue_comment(
+        &self,
+        request: &CreateIssueCommentRequest,
+    ) -> Result<(), Self::Error>;
+}
+
+#[async_trait]
+impl PreparedSyncExecutor for RemoteClient {
+    type Error = RemoteClientError;
+
+    async fn create_issue(&self, request: &CreateIssueRequest) -> Result<(), Self::Error> {
+        RemoteClient::create_issue(self, request).await.map(|_| ())
+    }
+
+    async fn update_issue(
+        &self,
+        issue_id: Uuid,
+        request: &UpdateIssueRequest,
+    ) -> Result<(), Self::Error> {
+        RemoteClient::update_issue(self, issue_id, request)
+            .await
+            .map(|_| ())
+    }
+
+    async fn create_issue_relationship(
+        &self,
+        request: &CreateIssueRelationshipRequest,
+    ) -> Result<(), Self::Error> {
+        RemoteClient::create_issue_relationship(self, request)
+            .await
+            .map(|_| ())
+    }
+
+    async fn create_issue_comment(
+        &self,
+        request: &CreateIssueCommentRequest,
+    ) -> Result<(), Self::Error> {
+        RemoteClient::create_issue_comment(self, request)
+            .await
+            .map(|_| ())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -581,6 +651,42 @@ pub fn prepare_sync_actions(plan: &SyncPlan, options: PrepareSyncOptions) -> Pre
     PreparedSync { actions }
 }
 
+pub async fn execute_prepared_sync<E>(
+    executor: &E,
+    prepared: &PreparedSync,
+) -> Result<ExecutedSyncSummary, E::Error>
+where
+    E: PreparedSyncExecutor + Sync,
+{
+    let mut summary = ExecutedSyncSummary::default();
+
+    for action in &prepared.actions {
+        match action {
+            PreparedSyncAction::CreateIssue(request) => {
+                executor.create_issue(request).await?;
+                summary.created_issues += 1;
+            }
+            PreparedSyncAction::UpdateIssue { issue_id, request } => {
+                executor.update_issue(*issue_id, request).await?;
+                summary.updated_issues += 1;
+            }
+            PreparedSyncAction::CreateIssueRelationship(request) => {
+                executor.create_issue_relationship(request).await?;
+                summary.created_relationships += 1;
+            }
+            PreparedSyncAction::CreateIssueComment(request) => {
+                executor.create_issue_comment(request).await?;
+                summary.created_comments += 1;
+            }
+            PreparedSyncAction::Unsupported(_) => {
+                summary.skipped_unsupported += 1;
+            }
+        }
+    }
+
+    Ok(summary)
+}
+
 pub fn format_mirrored_github_comment(
     github_comment_id: u64,
     author_login: &str,
@@ -634,6 +740,8 @@ fn empty_update_issue_request() -> UpdateIssueRequest {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
 
     fn make_uuid(n: u64) -> Uuid {
@@ -664,6 +772,68 @@ mod tests {
             github_issue_number: Some(gh_number),
             title: title.to_string(),
             description: None,
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum RecordedAction {
+        CreateIssue(String),
+        UpdateIssue(Uuid, Option<String>),
+        CreateRelationship(ApiIssueRelationshipType),
+        CreateComment(String),
+    }
+
+    #[derive(Default)]
+    struct RecordingExecutor {
+        actions: Mutex<Vec<RecordedAction>>,
+    }
+
+    #[async_trait]
+    impl PreparedSyncExecutor for RecordingExecutor {
+        type Error = &'static str;
+
+        async fn create_issue(&self, request: &CreateIssueRequest) -> Result<(), Self::Error> {
+            self.actions
+                .lock()
+                .map_err(|_| "recording executor poisoned")?
+                .push(RecordedAction::CreateIssue(request.title.clone()));
+            Ok(())
+        }
+
+        async fn update_issue(
+            &self,
+            issue_id: Uuid,
+            request: &UpdateIssueRequest,
+        ) -> Result<(), Self::Error> {
+            self.actions
+                .lock()
+                .map_err(|_| "recording executor poisoned")?
+                .push(RecordedAction::UpdateIssue(issue_id, request.title.clone()));
+            Ok(())
+        }
+
+        async fn create_issue_relationship(
+            &self,
+            request: &CreateIssueRelationshipRequest,
+        ) -> Result<(), Self::Error> {
+            self.actions
+                .lock()
+                .map_err(|_| "recording executor poisoned")?
+                .push(RecordedAction::CreateRelationship(
+                    request.relationship_type,
+                ));
+            Ok(())
+        }
+
+        async fn create_issue_comment(
+            &self,
+            request: &CreateIssueCommentRequest,
+        ) -> Result<(), Self::Error> {
+            self.actions
+                .lock()
+                .map_err(|_| "recording executor poisoned")?
+                .push(RecordedAction::CreateComment(request.message.clone()));
+            Ok(())
         }
     }
 
@@ -1100,6 +1270,88 @@ mod tests {
                 if request.message.contains("vibe-kanban-github-comment-id:2222")
                     && request.message.contains("@octocat")
         )));
+    }
+
+    #[tokio::test]
+    async fn executes_prepared_sync_against_mutation_surface() {
+        let issue_id = make_uuid(2000);
+        let project_id = make_uuid(2001);
+        let status_id = make_uuid(2002);
+        let prepared = PreparedSync {
+            actions: vec![
+                PreparedSyncAction::CreateIssue(CreateIssueRequest {
+                    id: Some(issue_id),
+                    project_id,
+                    status_id,
+                    title: "GitHub issue".into(),
+                    description: None,
+                    priority: None,
+                    start_date: None,
+                    target_date: None,
+                    completed_at: None,
+                    sort_order: 0.0,
+                    parent_issue_id: None,
+                    parent_issue_sort_order: None,
+                    extension_metadata: github_extension_metadata(
+                        200,
+                        "https://github.com/owner/repo/issues/200",
+                    ),
+                }),
+                PreparedSyncAction::UpdateIssue {
+                    issue_id,
+                    request: UpdateIssueRequest {
+                        title: Some("Renamed from GitHub".into()),
+                        ..empty_update_issue_request()
+                    },
+                },
+                PreparedSyncAction::CreateIssueRelationship(CreateIssueRelationshipRequest {
+                    id: None,
+                    issue_id,
+                    related_issue_id: make_uuid(2003),
+                    relationship_type: ApiIssueRelationshipType::Blocking,
+                }),
+                PreparedSyncAction::CreateIssueComment(CreateIssueCommentRequest {
+                    id: None,
+                    issue_id,
+                    message: format_mirrored_github_comment(1234, "octocat", "Kanban update"),
+                    parent_id: None,
+                }),
+                PreparedSyncAction::Unsupported(UnsupportedSyncItem::Tags {
+                    kanban_id: issue_id,
+                    tag_name: "p1".into(),
+                    reason: "not implemented".into(),
+                }),
+            ],
+        };
+        let executor = RecordingExecutor::default();
+
+        let summary = execute_prepared_sync(&executor, &prepared)
+            .await
+            .expect("executor should apply all supported actions");
+
+        assert_eq!(
+            summary,
+            ExecutedSyncSummary {
+                created_issues: 1,
+                updated_issues: 1,
+                created_relationships: 1,
+                created_comments: 1,
+                skipped_unsupported: 1,
+            }
+        );
+        assert_eq!(
+            *executor.actions.lock().expect("recorded actions"),
+            vec![
+                RecordedAction::CreateIssue("GitHub issue".into()),
+                RecordedAction::UpdateIssue(issue_id, Some("Renamed from GitHub".into())),
+                RecordedAction::CreateRelationship(ApiIssueRelationshipType::Blocking),
+                RecordedAction::CreateComment(format_mirrored_github_comment(
+                    1234,
+                    "octocat",
+                    "Kanban update"
+                )),
+            ]
+        );
     }
 
     #[test]

--- a/crates/services/src/services/github_sync_plan.rs
+++ b/crates/services/src/services/github_sync_plan.rs
@@ -1,0 +1,624 @@
+/// Opt-in GitHub → Vibe Kanban sync planning.
+///
+/// This module is deliberately side-effect-free: it takes a snapshot of GitHub issue
+/// data and the existing Kanban state, then produces a [`SyncPlan`] describing what
+/// mutations *would* need to happen. Callers decide whether/how to execute those ops.
+///
+/// Tracking issue: gavinanelson/implication#171
+///
+/// # Opt-in rule
+/// Sync is only triggered when Gavin explicitly requests a Kanban sync run. Nothing
+/// here runs automatically.
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// GitHub-side types (populated from GitHub REST/GraphQL responses)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitHubIssueState {
+    Open,
+    Closed,
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubLabel {
+    pub name: String,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubUser {
+    pub login: String,
+}
+
+/// A lightweight reference to another GitHub issue (used for sub-issues / links).
+#[derive(Debug, Clone)]
+pub struct GitHubIssueRef {
+    pub number: u64,
+    pub url: String,
+}
+
+/// A comment on a GitHub issue that should be mirrored into Kanban.
+/// Only comments marked for mirroring (e.g. status updates) are included —
+/// callers filter before constructing the snapshot.
+#[derive(Debug, Clone)]
+pub struct GitHubMirrorComment {
+    pub github_comment_id: u64,
+    pub author_login: String,
+    pub body: String,
+}
+
+/// Full snapshot of a GitHub issue as seen at sync time.
+#[derive(Debug, Clone)]
+pub struct GitHubIssue {
+    pub number: u64,
+    pub url: String,
+    pub title: String,
+    pub body: Option<String>,
+    pub state: GitHubIssueState,
+    pub labels: Vec<GitHubLabel>,
+    pub assignees: Vec<GitHubUser>,
+    /// Direct children in GitHub's sub-issue hierarchy.
+    pub sub_issues: Vec<GitHubIssueRef>,
+    /// Issues that block this one (parsed from "blocked by #N" links or GitHub's
+    /// tracked-in / sub-issue relationship metadata).
+    pub blocked_by: Vec<GitHubIssueRef>,
+    /// Peer issues that are related but not blocking.
+    pub related_issues: Vec<GitHubIssueRef>,
+    /// Status-update / notable comments to mirror as durable Kanban comments.
+    pub mirror_comments: Vec<GitHubMirrorComment>,
+}
+
+// ---------------------------------------------------------------------------
+// Kanban-side state (provided by caller from DB)
+// ---------------------------------------------------------------------------
+
+/// What we know about an existing Kanban issue that may already represent a
+/// GitHub issue.  The `github_issue_number` is persisted in `extension_metadata`
+/// (no schema migration required).
+#[derive(Debug, Clone)]
+pub struct KanbanIssueRef {
+    pub id: Uuid,
+    pub github_issue_number: Option<u64>,
+    pub title: String,
+    pub description: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Planned operations
+// ---------------------------------------------------------------------------
+
+/// A single mutation that the sync executor should apply to the Kanban board.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SyncOp {
+    /// Create a brand-new Kanban issue for a GitHub issue that has no match yet.
+    CreateIssue {
+        github_number: u64,
+        github_url: String,
+        title: String,
+        description: Option<String>,
+        /// If this GitHub issue is itself a sub-issue, link it under the parent.
+        parent_kanban_id: Option<Uuid>,
+    },
+
+    /// Bring an existing Kanban issue's title in line with GitHub.
+    UpdateTitle {
+        kanban_id: Uuid,
+        new_title: String,
+    },
+
+    /// Bring an existing Kanban issue's description in line with GitHub.
+    UpdateDescription {
+        kanban_id: Uuid,
+        new_description: Option<String>,
+    },
+
+    /// Establish a parent→child (sub-issue) link between two Kanban issues.
+    LinkSubIssue {
+        parent_kanban_id: Uuid,
+        child_kanban_id: Uuid,
+    },
+
+    /// Mirror a GitHub "blocked-by" dependency as a Kanban blocking relationship.
+    AddBlockingRelationship {
+        /// The issue doing the blocking (i.e. must be done first).
+        blocker_kanban_id: Uuid,
+        /// The issue that is blocked.
+        blocked_kanban_id: Uuid,
+    },
+
+    /// Mirror a GitHub "related" link as a Kanban related-issue link.
+    AddRelatedLink {
+        from_kanban_id: Uuid,
+        to_kanban_id: Uuid,
+    },
+
+    /// Ensure a tag with `tag_name` exists and is attached to the Kanban issue.
+    EnsureTag {
+        kanban_id: Uuid,
+        tag_name: String,
+    },
+
+    /// Append a durable status/comment from GitHub to the Kanban issue.
+    /// The `github_comment_id` lets executors deduplicate on re-runs.
+    /// TODO(#171): implement executor that writes Kanban comments via the remote API.
+    AddComment {
+        kanban_id: Uuid,
+        github_comment_id: u64,
+        author_login: String,
+        body: String,
+    },
+}
+
+/// The result of planning a sync run.
+#[derive(Debug, Default)]
+pub struct SyncPlan {
+    /// Ordered list of mutations the executor should apply.
+    pub ops: Vec<SyncOp>,
+    /// GitHub issue numbers that were referenced (sub-issue / blocked-by / related)
+    /// but were not present in the input snapshot.  Callers may fetch these and
+    /// re-plan, or surface them as warnings.
+    pub unresolved_github_refs: Vec<u64>,
+    /// Human-readable notes about deferred work.  Printed in sync summaries.
+    pub notes: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Planning logic
+// ---------------------------------------------------------------------------
+
+/// Build a [`SyncPlan`] from a GitHub snapshot and the current Kanban state.
+///
+/// The function is pure: it reads no DB, makes no HTTP calls, and has no side
+/// effects.  The caller is responsible for executing the returned ops.
+///
+/// `github_issues` — every GitHub issue in scope for this sync run.
+/// `existing_kanban` — every Kanban issue that might already track a GitHub issue.
+pub fn plan_sync(
+    github_issues: &[GitHubIssue],
+    existing_kanban: &[KanbanIssueRef],
+) -> SyncPlan {
+    let mut plan = SyncPlan::default();
+
+    // Build lookup: github issue number → kanban id (for already-tracked issues).
+    let kanban_by_gh_number: HashMap<u64, &KanbanIssueRef> = existing_kanban
+        .iter()
+        .filter_map(|k| k.github_issue_number.map(|n| (n, k)))
+        .collect();
+
+    // We'll also need to know which GitHub issue numbers are in scope so we can
+    // detect unresolved cross-references.
+    let gh_numbers_in_scope: std::collections::HashSet<u64> =
+        github_issues.iter().map(|i| i.number).collect();
+
+    for issue in github_issues {
+        let maybe_kanban = kanban_by_gh_number.get(&issue.number).copied();
+
+        // --- Create or update the issue itself ---
+        let kanban_id: Option<Uuid> = if let Some(kanban) = maybe_kanban {
+            if kanban.title != issue.title {
+                plan.ops.push(SyncOp::UpdateTitle {
+                    kanban_id: kanban.id,
+                    new_title: issue.title.clone(),
+                });
+            }
+            if kanban.description.as_deref() != issue.body.as_deref() {
+                plan.ops.push(SyncOp::UpdateDescription {
+                    kanban_id: kanban.id,
+                    new_description: issue.body.clone(),
+                });
+            }
+            Some(kanban.id)
+        } else {
+            plan.ops.push(SyncOp::CreateIssue {
+                github_number: issue.number,
+                github_url: issue.url.clone(),
+                title: issue.title.clone(),
+                description: issue.body.clone(),
+                parent_kanban_id: None, // sub-issue linkage handled below
+            });
+            None // kanban id not yet known; executor must resolve after create
+        };
+
+        // --- Sub-issues ---
+        for sub_ref in &issue.sub_issues {
+            if !gh_numbers_in_scope.contains(&sub_ref.number) {
+                plan.unresolved_github_refs.push(sub_ref.number);
+                continue;
+            }
+            if let (Some(parent_id), Some(child_kanban)) = (
+                kanban_id,
+                kanban_by_gh_number.get(&sub_ref.number).copied(),
+            ) {
+                plan.ops.push(SyncOp::LinkSubIssue {
+                    parent_kanban_id: parent_id,
+                    child_kanban_id: child_kanban.id,
+                });
+            }
+            // If parent or child doesn't have a kanban_id yet the executor must
+            // re-link after creating the missing issues.
+        }
+
+        // --- Blocked-by dependencies ---
+        for blocker_ref in &issue.blocked_by {
+            if !gh_numbers_in_scope.contains(&blocker_ref.number) {
+                plan.unresolved_github_refs.push(blocker_ref.number);
+                continue;
+            }
+            if let (Some(blocked_id), Some(blocker_kanban)) = (
+                kanban_id,
+                kanban_by_gh_number.get(&blocker_ref.number).copied(),
+            ) {
+                plan.ops.push(SyncOp::AddBlockingRelationship {
+                    blocker_kanban_id: blocker_kanban.id,
+                    blocked_kanban_id: blocked_id,
+                });
+            }
+        }
+
+        // --- Related links ---
+        for related_ref in &issue.related_issues {
+            if !gh_numbers_in_scope.contains(&related_ref.number) {
+                plan.unresolved_github_refs.push(related_ref.number);
+                continue;
+            }
+            if let (Some(from_id), Some(to_kanban)) = (
+                kanban_id,
+                kanban_by_gh_number.get(&related_ref.number).copied(),
+            ) {
+                plan.ops.push(SyncOp::AddRelatedLink {
+                    from_kanban_id: from_id,
+                    to_kanban_id: to_kanban.id,
+                });
+            }
+        }
+
+        // --- Labels → tags ---
+        if let Some(kid) = kanban_id {
+            for label in &issue.labels {
+                plan.ops.push(SyncOp::EnsureTag {
+                    kanban_id: kid,
+                    tag_name: label.name.clone(),
+                });
+            }
+        }
+
+        // --- Mirror comments ---
+        if let Some(kid) = kanban_id {
+            for comment in &issue.mirror_comments {
+                plan.ops.push(SyncOp::AddComment {
+                    kanban_id: kid,
+                    github_comment_id: comment.github_comment_id,
+                    author_login: comment.author_login.clone(),
+                    body: comment.body.clone(),
+                });
+            }
+        }
+    }
+
+    // Deduplicate unresolved refs.
+    plan.unresolved_github_refs.sort_unstable();
+    plan.unresolved_github_refs.dedup();
+
+    // Standing TODOs wired to the tracking issue.
+    plan.notes.push(
+        "TODO(#171): executor for SyncOp::CreateIssue via remote issues API".into(),
+    );
+    plan.notes.push(
+        "TODO(#171): executor for SyncOp::AddComment — write durable Kanban comments".into(),
+    );
+    plan.notes.push(
+        "TODO(#171): push-back from Kanban → GitHub (status, labels, assignees)".into(),
+    );
+    plan.notes.push(
+        "TODO(#171): GitHub GraphQL sub-issue query to populate GitHubIssue.sub_issues".into(),
+    );
+
+    plan
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_uuid(n: u64) -> Uuid {
+        // Deterministic UUIDs for test readability.
+        Uuid::from_u128(n as u128)
+    }
+
+    fn simple_gh_issue(number: u64, title: &str) -> GitHubIssue {
+        GitHubIssue {
+            number,
+            url: format!("https://github.com/owner/repo/issues/{number}"),
+            title: title.to_string(),
+            body: None,
+            state: GitHubIssueState::Open,
+            labels: vec![],
+            assignees: vec![],
+            sub_issues: vec![],
+            blocked_by: vec![],
+            related_issues: vec![],
+            mirror_comments: vec![],
+        }
+    }
+
+    fn kanban_ref(id_n: u64, gh_number: u64, title: &str) -> KanbanIssueRef {
+        KanbanIssueRef {
+            id: make_uuid(id_n),
+            github_issue_number: Some(gh_number),
+            title: title.to_string(),
+            description: None,
+        }
+    }
+
+    // --- CreateIssue ---
+
+    #[test]
+    fn creates_issue_when_no_kanban_match() {
+        let gh = [simple_gh_issue(42, "New feature")];
+        let plan = plan_sync(&gh, &[]);
+
+        assert_eq!(plan.ops.len(), 1, "expected exactly one op");
+        assert!(
+            matches!(
+                &plan.ops[0],
+                SyncOp::CreateIssue { github_number: 42, .. }
+            ),
+            "expected CreateIssue"
+        );
+        // Notes for TODO items should always be present.
+        assert!(!plan.notes.is_empty());
+    }
+
+    #[test]
+    fn no_create_when_already_tracked() {
+        let gh = [simple_gh_issue(7, "Same title")];
+        let kanban = [kanban_ref(1, 7, "Same title")];
+        let plan = plan_sync(&gh, &kanban);
+
+        let creates: Vec<_> = plan
+            .ops
+            .iter()
+            .filter(|op| matches!(op, SyncOp::CreateIssue { .. }))
+            .collect();
+        assert!(creates.is_empty(), "should not create an already-tracked issue");
+    }
+
+    // --- UpdateTitle ---
+
+    #[test]
+    fn emits_title_update_when_title_differs() {
+        let gh = [simple_gh_issue(10, "Renamed title")];
+        let kanban = [kanban_ref(1, 10, "Old title")];
+        let plan = plan_sync(&gh, &kanban);
+
+        let updates: Vec<_> = plan
+            .ops
+            .iter()
+            .filter(|op| matches!(op, SyncOp::UpdateTitle { .. }))
+            .collect();
+        assert_eq!(updates.len(), 1);
+        assert!(
+            matches!(
+                updates[0],
+                SyncOp::UpdateTitle { new_title, .. } if new_title == "Renamed title"
+            )
+        );
+    }
+
+    #[test]
+    fn no_title_update_when_title_matches() {
+        let gh = [simple_gh_issue(10, "Same")];
+        let kanban = [kanban_ref(1, 10, "Same")];
+        let plan = plan_sync(&gh, &kanban);
+
+        assert!(
+            !plan
+                .ops
+                .iter()
+                .any(|op| matches!(op, SyncOp::UpdateTitle { .. })),
+            "should not emit title update when title is unchanged"
+        );
+    }
+
+    // --- UpdateDescription ---
+
+    #[test]
+    fn emits_description_update_when_body_differs() {
+        let mut gh = simple_gh_issue(5, "Title");
+        gh.body = Some("New body".into());
+        let kanban = [KanbanIssueRef {
+            id: make_uuid(1),
+            github_issue_number: Some(5),
+            title: "Title".into(),
+            description: Some("Old body".into()),
+        }];
+        let plan = plan_sync(&[gh], &kanban);
+
+        assert!(
+            plan.ops
+                .iter()
+                .any(|op| matches!(op, SyncOp::UpdateDescription { new_description: Some(d), .. } if d == "New body")),
+            "expected UpdateDescription"
+        );
+    }
+
+    // --- LinkSubIssue ---
+
+    #[test]
+    fn emits_sub_issue_link_when_both_tracked() {
+        let mut parent = simple_gh_issue(1, "Parent");
+        parent.sub_issues = vec![GitHubIssueRef {
+            number: 2,
+            url: "https://github.com/owner/repo/issues/2".into(),
+        }];
+        let child = simple_gh_issue(2, "Child");
+
+        let kanban = [kanban_ref(10, 1, "Parent"), kanban_ref(20, 2, "Child")];
+        let plan = plan_sync(&[parent, child], &kanban);
+
+        assert!(
+            plan.ops.iter().any(|op| matches!(
+                op,
+                SyncOp::LinkSubIssue {
+                    parent_kanban_id,
+                    child_kanban_id,
+                } if *parent_kanban_id == make_uuid(10) && *child_kanban_id == make_uuid(20)
+            )),
+            "expected LinkSubIssue"
+        );
+    }
+
+    #[test]
+    fn unresolved_ref_when_sub_issue_not_in_scope() {
+        let mut parent = simple_gh_issue(1, "Parent");
+        parent.sub_issues = vec![GitHubIssueRef {
+            number: 99,
+            url: "https://github.com/owner/repo/issues/99".into(),
+        }];
+        let plan = plan_sync(&[parent], &[]);
+
+        assert!(
+            plan.unresolved_github_refs.contains(&99),
+            "should record unresolved sub-issue ref"
+        );
+    }
+
+    // --- Blocking relationship ---
+
+    #[test]
+    fn emits_blocking_relationship_when_both_tracked() {
+        let mut issue_a = simple_gh_issue(3, "A");
+        issue_a.blocked_by = vec![GitHubIssueRef {
+            number: 4,
+            url: "https://github.com/owner/repo/issues/4".into(),
+        }];
+        let issue_b = simple_gh_issue(4, "B");
+
+        let kanban = [kanban_ref(30, 3, "A"), kanban_ref(40, 4, "B")];
+        let plan = plan_sync(&[issue_a, issue_b], &kanban);
+
+        assert!(
+            plan.ops.iter().any(|op| matches!(
+                op,
+                SyncOp::AddBlockingRelationship {
+                    blocker_kanban_id,
+                    blocked_kanban_id,
+                } if *blocker_kanban_id == make_uuid(40) && *blocked_kanban_id == make_uuid(30)
+            )),
+            "expected AddBlockingRelationship with correct blocker/blocked direction"
+        );
+    }
+
+    // --- Related link ---
+
+    #[test]
+    fn emits_related_link_when_both_tracked() {
+        let mut issue_x = simple_gh_issue(5, "X");
+        issue_x.related_issues = vec![GitHubIssueRef {
+            number: 6,
+            url: "https://github.com/owner/repo/issues/6".into(),
+        }];
+        let issue_y = simple_gh_issue(6, "Y");
+
+        let kanban = [kanban_ref(50, 5, "X"), kanban_ref(60, 6, "Y")];
+        let plan = plan_sync(&[issue_x, issue_y], &kanban);
+
+        assert!(
+            plan.ops
+                .iter()
+                .any(|op| matches!(op, SyncOp::AddRelatedLink { .. })),
+            "expected AddRelatedLink"
+        );
+    }
+
+    // --- Labels → tags ---
+
+    #[test]
+    fn emits_ensure_tag_for_each_label() {
+        let mut gh = simple_gh_issue(7, "Tagged");
+        gh.labels = vec![
+            GitHubLabel { name: "bug".into(), color: Some("d73a4a".into()) },
+            GitHubLabel { name: "p1".into(), color: None },
+        ];
+        let kanban = [kanban_ref(70, 7, "Tagged")];
+        let plan = plan_sync(&[gh], &kanban);
+
+        let tags: Vec<_> = plan
+            .ops
+            .iter()
+            .filter_map(|op| {
+                if let SyncOp::EnsureTag { tag_name, .. } = op {
+                    Some(tag_name.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(tags.contains(&"bug"), "expected 'bug' tag");
+        assert!(tags.contains(&"p1"), "expected 'p1' tag");
+    }
+
+    // --- Mirror comments ---
+
+    #[test]
+    fn emits_add_comment_for_mirror_comments() {
+        let mut gh = simple_gh_issue(8, "With comment");
+        gh.mirror_comments = vec![GitHubMirrorComment {
+            github_comment_id: 9999,
+            author_login: "alice".into(),
+            body: "Status: shipped".into(),
+        }];
+        let kanban = [kanban_ref(80, 8, "With comment")];
+        let plan = plan_sync(&[gh], &kanban);
+
+        assert!(
+            plan.ops.iter().any(|op| matches!(
+                op,
+                SyncOp::AddComment { github_comment_id: 9999, .. }
+            )),
+            "expected AddComment for mirror comment"
+        );
+    }
+
+    // --- Deduplication of unresolved refs ---
+
+    #[test]
+    fn deduplicates_unresolved_refs() {
+        let mut issue_a = simple_gh_issue(1, "A");
+        issue_a.blocked_by = vec![GitHubIssueRef {
+            number: 99,
+            url: "https://github.com/owner/repo/issues/99".into(),
+        }];
+        let mut issue_b = simple_gh_issue(2, "B");
+        issue_b.related_issues = vec![GitHubIssueRef {
+            number: 99,
+            url: "https://github.com/owner/repo/issues/99".into(),
+        }];
+        let plan = plan_sync(&[issue_a, issue_b], &[]);
+
+        let count_99 = plan
+            .unresolved_github_refs
+            .iter()
+            .filter(|&&n| n == 99)
+            .count();
+        assert_eq!(count_99, 1, "unresolved refs should be deduplicated");
+    }
+
+    // --- Empty inputs ---
+
+    #[test]
+    fn empty_inputs_produce_empty_plan() {
+        let plan = plan_sync(&[], &[]);
+        assert!(plan.ops.is_empty());
+        assert!(plan.unresolved_github_refs.is_empty());
+        assert!(!plan.notes.is_empty(), "notes (TODOs) should always be populated");
+    }
+}

--- a/crates/services/src/services/github_sync_plan.rs
+++ b/crates/services/src/services/github_sync_plan.rs
@@ -9,8 +9,13 @@
 /// # Opt-in rule
 /// Sync is only triggered when Gavin explicitly requests a Kanban sync run. Nothing
 /// here runs automatically.
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use api_types::{
+    CreateIssueCommentRequest, CreateIssueRelationshipRequest, CreateIssueRequest,
+    IssueRelationshipType as ApiIssueRelationshipType, UpdateIssueRequest,
+};
+use serde_json::json;
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -70,6 +75,22 @@ pub struct GitHubIssue {
     pub related_issues: Vec<GitHubIssueRef>,
     /// Status-update / notable comments to mirror as durable Kanban comments.
     pub mirror_comments: Vec<GitHubMirrorComment>,
+    /// GitHub relationship metadata this runtime could not fetch safely.
+    pub unsupported_relations: Vec<UnsupportedGitHubRelation>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitHubRelationKind {
+    SubIssues,
+    BlockedBy,
+    Related,
+    Comments,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnsupportedGitHubRelation {
+    pub kind: GitHubRelationKind,
+    pub reason: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -87,6 +108,32 @@ pub struct KanbanIssueRef {
     pub description: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KanbanRelationshipType {
+    Blocking,
+    Related,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KanbanRelationshipRef {
+    pub from_kanban_id: Uuid,
+    pub to_kanban_id: Uuid,
+    pub relationship_type: KanbanRelationshipType,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KanbanMirroredCommentRef {
+    pub kanban_id: Uuid,
+    pub github_comment_id: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct KanbanSyncState {
+    pub issues: Vec<KanbanIssueRef>,
+    pub relationships: Vec<KanbanRelationshipRef>,
+    pub mirrored_comments: Vec<KanbanMirroredCommentRef>,
+}
+
 // ---------------------------------------------------------------------------
 // Planned operations
 // ---------------------------------------------------------------------------
@@ -96,6 +143,8 @@ pub struct KanbanIssueRef {
 pub enum SyncOp {
     /// Create a brand-new Kanban issue for a GitHub issue that has no match yet.
     CreateIssue {
+        /// Client-generated ID reserved during planning so later ops can refer to it.
+        kanban_id: Uuid,
         github_number: u64,
         github_url: String,
         title: String,
@@ -105,10 +154,7 @@ pub enum SyncOp {
     },
 
     /// Bring an existing Kanban issue's title in line with GitHub.
-    UpdateTitle {
-        kanban_id: Uuid,
-        new_title: String,
-    },
+    UpdateTitle { kanban_id: Uuid, new_title: String },
 
     /// Bring an existing Kanban issue's description in line with GitHub.
     UpdateDescription {
@@ -137,10 +183,7 @@ pub enum SyncOp {
     },
 
     /// Ensure a tag with `tag_name` exists and is attached to the Kanban issue.
-    EnsureTag {
-        kanban_id: Uuid,
-        tag_name: String,
-    },
+    EnsureTag { kanban_id: Uuid, tag_name: String },
 
     /// Append a durable status/comment from GitHub to the Kanban issue.
     /// The `github_comment_id` lets executors deduplicate on re-runs.
@@ -164,6 +207,46 @@ pub struct SyncPlan {
     pub unresolved_github_refs: Vec<u64>,
     /// Human-readable notes about deferred work.  Printed in sync summaries.
     pub notes: Vec<String>,
+    /// Work that is intentionally not guessed by this sync slice.
+    pub unsupported: Vec<UnsupportedSyncItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnsupportedSyncItem {
+    GitHubRelation {
+        github_number: u64,
+        kind: GitHubRelationKind,
+        reason: String,
+    },
+    Tags {
+        kanban_id: Uuid,
+        tag_name: String,
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct PrepareSyncOptions {
+    pub project_id: Uuid,
+    pub default_status_id: Uuid,
+    pub default_sort_order: f64,
+}
+
+#[derive(Debug, Clone)]
+pub enum PreparedSyncAction {
+    CreateIssue(CreateIssueRequest),
+    UpdateIssue {
+        issue_id: Uuid,
+        request: UpdateIssueRequest,
+    },
+    CreateIssueRelationship(CreateIssueRelationshipRequest),
+    CreateIssueComment(CreateIssueCommentRequest),
+    Unsupported(UnsupportedSyncItem),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PreparedSync {
+    pub actions: Vec<PreparedSyncAction>,
 }
 
 // ---------------------------------------------------------------------------
@@ -177,25 +260,59 @@ pub struct SyncPlan {
 ///
 /// `github_issues` — every GitHub issue in scope for this sync run.
 /// `existing_kanban` — every Kanban issue that might already track a GitHub issue.
-pub fn plan_sync(
-    github_issues: &[GitHubIssue],
-    existing_kanban: &[KanbanIssueRef],
-) -> SyncPlan {
+pub fn plan_sync(github_issues: &[GitHubIssue], existing_kanban: &[KanbanIssueRef]) -> SyncPlan {
+    plan_sync_with_state(
+        github_issues,
+        &KanbanSyncState {
+            issues: existing_kanban.to_vec(),
+            relationships: Vec::new(),
+            mirrored_comments: Vec::new(),
+        },
+    )
+}
+
+pub fn plan_sync_with_state(github_issues: &[GitHubIssue], state: &KanbanSyncState) -> SyncPlan {
     let mut plan = SyncPlan::default();
 
     // Build lookup: github issue number → kanban id (for already-tracked issues).
-    let kanban_by_gh_number: HashMap<u64, &KanbanIssueRef> = existing_kanban
+    let kanban_by_gh_number: HashMap<u64, &KanbanIssueRef> = state
+        .issues
         .iter()
         .filter_map(|k| k.github_issue_number.map(|n| (n, k)))
         .collect();
+    let mut planned_kanban_by_gh_number: HashMap<u64, Uuid> = HashMap::new();
+    for issue in github_issues {
+        let kanban_id = kanban_by_gh_number
+            .get(&issue.number)
+            .map(|kanban| kanban.id)
+            .unwrap_or_else(Uuid::new_v4);
+        planned_kanban_by_gh_number.insert(issue.number, kanban_id);
+    }
 
     // We'll also need to know which GitHub issue numbers are in scope so we can
     // detect unresolved cross-references.
-    let gh_numbers_in_scope: std::collections::HashSet<u64> =
-        github_issues.iter().map(|i| i.number).collect();
+    let gh_numbers_in_scope: HashSet<u64> = github_issues.iter().map(|i| i.number).collect();
+
+    let existing_relationships: HashSet<KanbanRelationshipRef> =
+        state.relationships.iter().copied().collect();
+    let existing_comments: HashSet<KanbanMirroredCommentRef> =
+        state.mirrored_comments.iter().copied().collect();
 
     for issue in github_issues {
         let maybe_kanban = kanban_by_gh_number.get(&issue.number).copied();
+        let planned_kanban_id = planned_kanban_by_gh_number[&issue.number];
+
+        for unsupported in &issue.unsupported_relations {
+            plan.unsupported.push(UnsupportedSyncItem::GitHubRelation {
+                github_number: issue.number,
+                kind: unsupported.kind,
+                reason: unsupported.reason.clone(),
+            });
+            plan.notes.push(format!(
+                "GitHub issue #{} {:?} needs manual sync: {}",
+                issue.number, unsupported.kind, unsupported.reason
+            ));
+        }
 
         // --- Create or update the issue itself ---
         let kanban_id: Option<Uuid> = if let Some(kanban) = maybe_kanban {
@@ -213,14 +330,24 @@ pub fn plan_sync(
             }
             Some(kanban.id)
         } else {
+            let parent_kanban_id = github_issues
+                .iter()
+                .find(|candidate| {
+                    candidate
+                        .sub_issues
+                        .iter()
+                        .any(|sub_ref| sub_ref.number == issue.number)
+                })
+                .and_then(|parent| planned_kanban_by_gh_number.get(&parent.number).copied());
             plan.ops.push(SyncOp::CreateIssue {
+                kanban_id: planned_kanban_id,
                 github_number: issue.number,
                 github_url: issue.url.clone(),
                 title: issue.title.clone(),
                 description: issue.body.clone(),
-                parent_kanban_id: None, // sub-issue linkage handled below
+                parent_kanban_id,
             });
-            None // kanban id not yet known; executor must resolve after create
+            Some(planned_kanban_id)
         };
 
         // --- Sub-issues ---
@@ -229,17 +356,15 @@ pub fn plan_sync(
                 plan.unresolved_github_refs.push(sub_ref.number);
                 continue;
             }
-            if let (Some(parent_id), Some(child_kanban)) = (
-                kanban_id,
-                kanban_by_gh_number.get(&sub_ref.number).copied(),
-            ) {
+            if let (Some(parent_id), Some(child_kanban)) =
+                (kanban_id, kanban_by_gh_number.get(&sub_ref.number).copied())
+                && child_kanban.id != parent_id
+            {
                 plan.ops.push(SyncOp::LinkSubIssue {
                     parent_kanban_id: parent_id,
                     child_kanban_id: child_kanban.id,
                 });
             }
-            // If parent or child doesn't have a kanban_id yet the executor must
-            // re-link after creating the missing issues.
         }
 
         // --- Blocked-by dependencies ---
@@ -250,12 +375,21 @@ pub fn plan_sync(
             }
             if let (Some(blocked_id), Some(blocker_kanban)) = (
                 kanban_id,
-                kanban_by_gh_number.get(&blocker_ref.number).copied(),
+                planned_kanban_by_gh_number
+                    .get(&blocker_ref.number)
+                    .copied(),
             ) {
-                plan.ops.push(SyncOp::AddBlockingRelationship {
-                    blocker_kanban_id: blocker_kanban.id,
-                    blocked_kanban_id: blocked_id,
-                });
+                let relationship = KanbanRelationshipRef {
+                    from_kanban_id: blocker_kanban,
+                    to_kanban_id: blocked_id,
+                    relationship_type: KanbanRelationshipType::Blocking,
+                };
+                if !existing_relationships.contains(&relationship) {
+                    plan.ops.push(SyncOp::AddBlockingRelationship {
+                        blocker_kanban_id: relationship.from_kanban_id,
+                        blocked_kanban_id: relationship.to_kanban_id,
+                    });
+                }
             }
         }
 
@@ -267,12 +401,21 @@ pub fn plan_sync(
             }
             if let (Some(from_id), Some(to_kanban)) = (
                 kanban_id,
-                kanban_by_gh_number.get(&related_ref.number).copied(),
+                planned_kanban_by_gh_number
+                    .get(&related_ref.number)
+                    .copied(),
             ) {
-                plan.ops.push(SyncOp::AddRelatedLink {
+                let relationship = KanbanRelationshipRef {
                     from_kanban_id: from_id,
-                    to_kanban_id: to_kanban.id,
-                });
+                    to_kanban_id: to_kanban,
+                    relationship_type: KanbanRelationshipType::Related,
+                };
+                if !existing_relationships.contains(&relationship) {
+                    plan.ops.push(SyncOp::AddRelatedLink {
+                        from_kanban_id: relationship.from_kanban_id,
+                        to_kanban_id: relationship.to_kanban_id,
+                    });
+                }
             }
         }
 
@@ -289,12 +432,18 @@ pub fn plan_sync(
         // --- Mirror comments ---
         if let Some(kid) = kanban_id {
             for comment in &issue.mirror_comments {
-                plan.ops.push(SyncOp::AddComment {
+                let mirrored = KanbanMirroredCommentRef {
                     kanban_id: kid,
                     github_comment_id: comment.github_comment_id,
-                    author_login: comment.author_login.clone(),
-                    body: comment.body.clone(),
-                });
+                };
+                if !existing_comments.contains(&mirrored) {
+                    plan.ops.push(SyncOp::AddComment {
+                        kanban_id: kid,
+                        github_comment_id: comment.github_comment_id,
+                        author_login: comment.author_login.clone(),
+                        body: comment.body.clone(),
+                    });
+                }
             }
         }
     }
@@ -303,21 +452,180 @@ pub fn plan_sync(
     plan.unresolved_github_refs.sort_unstable();
     plan.unresolved_github_refs.dedup();
 
-    // Standing TODOs wired to the tracking issue.
-    plan.notes.push(
-        "TODO(#171): executor for SyncOp::CreateIssue via remote issues API".into(),
-    );
-    plan.notes.push(
-        "TODO(#171): executor for SyncOp::AddComment — write durable Kanban comments".into(),
-    );
-    plan.notes.push(
-        "TODO(#171): push-back from Kanban → GitHub (status, labels, assignees)".into(),
-    );
-    plan.notes.push(
-        "TODO(#171): GitHub GraphQL sub-issue query to populate GitHubIssue.sub_issues".into(),
-    );
+    plan.notes
+        .push("TODO(#171): push-back from Kanban → GitHub (status, labels, assignees)".into());
 
     plan
+}
+
+pub fn prepare_sync_actions(plan: &SyncPlan, options: PrepareSyncOptions) -> PreparedSync {
+    let mut issue_actions = Vec::new();
+    let mut relationship_actions = Vec::new();
+    let mut comment_actions = Vec::new();
+    let mut unsupported_actions = Vec::new();
+
+    for op in &plan.ops {
+        match op {
+            SyncOp::CreateIssue {
+                kanban_id,
+                github_number,
+                github_url,
+                title,
+                description,
+                parent_kanban_id,
+            } => issue_actions.push(PreparedSyncAction::CreateIssue(CreateIssueRequest {
+                id: Some(*kanban_id),
+                project_id: options.project_id,
+                status_id: options.default_status_id,
+                title: title.clone(),
+                description: description.clone(),
+                priority: None,
+                start_date: None,
+                target_date: None,
+                completed_at: None,
+                sort_order: options.default_sort_order,
+                parent_issue_id: *parent_kanban_id,
+                parent_issue_sort_order: None,
+                extension_metadata: github_extension_metadata(*github_number, github_url),
+            })),
+            SyncOp::UpdateTitle {
+                kanban_id,
+                new_title,
+            } => issue_actions.push(PreparedSyncAction::UpdateIssue {
+                issue_id: *kanban_id,
+                request: UpdateIssueRequest {
+                    title: Some(new_title.clone()),
+                    ..empty_update_issue_request()
+                },
+            }),
+            SyncOp::UpdateDescription {
+                kanban_id,
+                new_description,
+            } => issue_actions.push(PreparedSyncAction::UpdateIssue {
+                issue_id: *kanban_id,
+                request: UpdateIssueRequest {
+                    description: Some(new_description.clone()),
+                    ..empty_update_issue_request()
+                },
+            }),
+            SyncOp::LinkSubIssue {
+                parent_kanban_id,
+                child_kanban_id,
+            } => issue_actions.push(PreparedSyncAction::UpdateIssue {
+                issue_id: *child_kanban_id,
+                request: UpdateIssueRequest {
+                    parent_issue_id: Some(Some(*parent_kanban_id)),
+                    ..empty_update_issue_request()
+                },
+            }),
+            SyncOp::AddBlockingRelationship {
+                blocker_kanban_id,
+                blocked_kanban_id,
+            } => relationship_actions.push(PreparedSyncAction::CreateIssueRelationship(
+                CreateIssueRelationshipRequest {
+                    id: None,
+                    issue_id: *blocker_kanban_id,
+                    related_issue_id: *blocked_kanban_id,
+                    relationship_type: ApiIssueRelationshipType::Blocking,
+                },
+            )),
+            SyncOp::AddRelatedLink {
+                from_kanban_id,
+                to_kanban_id,
+            } => relationship_actions.push(PreparedSyncAction::CreateIssueRelationship(
+                CreateIssueRelationshipRequest {
+                    id: None,
+                    issue_id: *from_kanban_id,
+                    related_issue_id: *to_kanban_id,
+                    relationship_type: ApiIssueRelationshipType::Related,
+                },
+            )),
+            SyncOp::EnsureTag {
+                kanban_id,
+                tag_name,
+            } => unsupported_actions.push(PreparedSyncAction::Unsupported(
+                UnsupportedSyncItem::Tags {
+                    kanban_id: *kanban_id,
+                    tag_name: tag_name.clone(),
+                    reason: "Kanban tag API mapping is not available in github_sync_plan".into(),
+                },
+            )),
+            SyncOp::AddComment {
+                kanban_id,
+                github_comment_id,
+                author_login,
+                body,
+            } => comment_actions.push(PreparedSyncAction::CreateIssueComment(
+                CreateIssueCommentRequest {
+                    id: None,
+                    issue_id: *kanban_id,
+                    message: format_mirrored_github_comment(*github_comment_id, author_login, body),
+                    parent_id: None,
+                },
+            )),
+        }
+    }
+
+    unsupported_actions.extend(
+        plan.unsupported
+            .iter()
+            .cloned()
+            .map(PreparedSyncAction::Unsupported),
+    );
+
+    let mut actions = issue_actions;
+    actions.extend(relationship_actions);
+    actions.extend(comment_actions);
+    actions.extend(unsupported_actions);
+
+    PreparedSync { actions }
+}
+
+pub fn format_mirrored_github_comment(
+    github_comment_id: u64,
+    author_login: &str,
+    body: &str,
+) -> String {
+    format!(
+        "GitHub comment by @{author_login}:\n\n{body}\n\n<!-- vibe-kanban-github-comment-id:{github_comment_id} -->"
+    )
+}
+
+pub fn github_comment_id_from_kanban_message(message: &str) -> Option<u64> {
+    let marker = "vibe-kanban-github-comment-id:";
+    let start = message.find(marker)? + marker.len();
+    let tail = &message[start..];
+    let digits: String = tail.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+fn github_extension_metadata(github_number: u64, github_url: &str) -> serde_json::Value {
+    json!({
+        "github": {
+            "issue_number": github_number,
+            "url": github_url,
+            "sync": {
+                "source": "github",
+                "mode": "opt_in"
+            }
+        }
+    })
+}
+
+fn empty_update_issue_request() -> UpdateIssueRequest {
+    UpdateIssueRequest {
+        status_id: None,
+        title: None,
+        description: None,
+        priority: None,
+        start_date: None,
+        target_date: None,
+        completed_at: None,
+        sort_order: None,
+        parent_issue_id: None,
+        parent_issue_sort_order: None,
+        extension_metadata: None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -346,6 +654,7 @@ mod tests {
             blocked_by: vec![],
             related_issues: vec![],
             mirror_comments: vec![],
+            unsupported_relations: vec![],
         }
     }
 
@@ -369,7 +678,10 @@ mod tests {
         assert!(
             matches!(
                 &plan.ops[0],
-                SyncOp::CreateIssue { github_number: 42, .. }
+                SyncOp::CreateIssue {
+                    github_number: 42,
+                    ..
+                }
             ),
             "expected CreateIssue"
         );
@@ -388,7 +700,10 @@ mod tests {
             .iter()
             .filter(|op| matches!(op, SyncOp::CreateIssue { .. }))
             .collect();
-        assert!(creates.is_empty(), "should not create an already-tracked issue");
+        assert!(
+            creates.is_empty(),
+            "should not create an already-tracked issue"
+        );
     }
 
     // --- UpdateTitle ---
@@ -405,12 +720,10 @@ mod tests {
             .filter(|op| matches!(op, SyncOp::UpdateTitle { .. }))
             .collect();
         assert_eq!(updates.len(), 1);
-        assert!(
-            matches!(
-                updates[0],
-                SyncOp::UpdateTitle { new_title, .. } if new_title == "Renamed title"
-            )
-        );
+        assert!(matches!(
+            updates[0],
+            SyncOp::UpdateTitle { new_title, .. } if new_title == "Renamed title"
+        ));
     }
 
     #[test]
@@ -545,8 +858,14 @@ mod tests {
     fn emits_ensure_tag_for_each_label() {
         let mut gh = simple_gh_issue(7, "Tagged");
         gh.labels = vec![
-            GitHubLabel { name: "bug".into(), color: Some("d73a4a".into()) },
-            GitHubLabel { name: "p1".into(), color: None },
+            GitHubLabel {
+                name: "bug".into(),
+                color: Some("d73a4a".into()),
+            },
+            GitHubLabel {
+                name: "p1".into(),
+                color: None,
+            },
         ];
         let kanban = [kanban_ref(70, 7, "Tagged")];
         let plan = plan_sync(&[gh], &kanban);
@@ -582,7 +901,10 @@ mod tests {
         assert!(
             plan.ops.iter().any(|op| matches!(
                 op,
-                SyncOp::AddComment { github_comment_id: 9999, .. }
+                SyncOp::AddComment {
+                    github_comment_id: 9999,
+                    ..
+                }
             )),
             "expected AddComment for mirror comment"
         );
@@ -619,6 +941,189 @@ mod tests {
         let plan = plan_sync(&[], &[]);
         assert!(plan.ops.is_empty());
         assert!(plan.unresolved_github_refs.is_empty());
-        assert!(!plan.notes.is_empty(), "notes (TODOs) should always be populated");
+        assert!(
+            !plan.notes.is_empty(),
+            "notes (TODOs) should always be populated"
+        );
+    }
+
+    #[test]
+    fn creates_sub_issue_with_reserved_parent_id_when_both_missing() {
+        let mut parent = simple_gh_issue(1, "Parent");
+        parent.sub_issues = vec![GitHubIssueRef {
+            number: 2,
+            url: "https://github.com/owner/repo/issues/2".into(),
+        }];
+        let child = simple_gh_issue(2, "Child");
+
+        let plan = plan_sync(&[parent, child], &[]);
+
+        let parent_id = plan
+            .ops
+            .iter()
+            .find_map(|op| match op {
+                SyncOp::CreateIssue {
+                    github_number: 1,
+                    kanban_id,
+                    ..
+                } => Some(*kanban_id),
+                _ => None,
+            })
+            .expect("parent create should reserve a kanban id");
+
+        assert!(
+            plan.ops.iter().any(|op| matches!(
+                op,
+                SyncOp::CreateIssue {
+                    github_number: 2,
+                    parent_kanban_id: Some(id),
+                    ..
+                } if *id == parent_id
+            )),
+            "child create should point at the reserved parent id"
+        );
+    }
+
+    #[test]
+    fn skips_relationships_and_comments_already_mirrored_in_state() {
+        let mut issue = simple_gh_issue(10, "Blocked");
+        issue.blocked_by = vec![GitHubIssueRef {
+            number: 11,
+            url: "https://github.com/owner/repo/issues/11".into(),
+        }];
+        issue.related_issues = vec![GitHubIssueRef {
+            number: 12,
+            url: "https://github.com/owner/repo/issues/12".into(),
+        }];
+        issue.mirror_comments = vec![GitHubMirrorComment {
+            github_comment_id: 500,
+            author_login: "alice".into(),
+            body: "Already imported".into(),
+        }];
+
+        let blocker = simple_gh_issue(11, "Blocker");
+        let related = simple_gh_issue(12, "Related");
+        let state = KanbanSyncState {
+            issues: vec![
+                kanban_ref(10, 10, "Blocked"),
+                kanban_ref(11, 11, "Blocker"),
+                kanban_ref(12, 12, "Related"),
+            ],
+            relationships: vec![
+                KanbanRelationshipRef {
+                    from_kanban_id: make_uuid(11),
+                    to_kanban_id: make_uuid(10),
+                    relationship_type: KanbanRelationshipType::Blocking,
+                },
+                KanbanRelationshipRef {
+                    from_kanban_id: make_uuid(10),
+                    to_kanban_id: make_uuid(12),
+                    relationship_type: KanbanRelationshipType::Related,
+                },
+            ],
+            mirrored_comments: vec![KanbanMirroredCommentRef {
+                kanban_id: make_uuid(10),
+                github_comment_id: 500,
+            }],
+        };
+
+        let plan = plan_sync_with_state(&[issue, blocker, related], &state);
+
+        assert!(
+            !plan
+                .ops
+                .iter()
+                .any(|op| matches!(op, SyncOp::AddBlockingRelationship { .. })),
+            "existing blocking relationship should not be duplicated"
+        );
+        assert!(
+            !plan
+                .ops
+                .iter()
+                .any(|op| matches!(op, SyncOp::AddRelatedLink { .. })),
+            "existing related relationship should not be duplicated"
+        );
+        assert!(
+            !plan
+                .ops
+                .iter()
+                .any(|op| matches!(op, SyncOp::AddComment { .. })),
+            "existing mirrored comment should not be duplicated"
+        );
+    }
+
+    #[test]
+    fn prepares_remote_api_actions_for_creates_updates_relationships_and_comments() {
+        let project_id = make_uuid(1000);
+        let status_id = make_uuid(1001);
+
+        let mut issue = simple_gh_issue(21, "Parent");
+        issue.body = Some("Canonical body".into());
+        issue.sub_issues = vec![GitHubIssueRef {
+            number: 22,
+            url: "https://github.com/owner/repo/issues/22".into(),
+        }];
+        issue.mirror_comments = vec![GitHubMirrorComment {
+            github_comment_id: 2222,
+            author_login: "octocat".into(),
+            body: "Kanban update: ready".into(),
+        }];
+        let child = simple_gh_issue(22, "Child");
+
+        let plan = plan_sync(&[issue, child], &[]);
+        let prepared = prepare_sync_actions(
+            &plan,
+            PrepareSyncOptions {
+                project_id,
+                default_status_id: status_id,
+                default_sort_order: 0.0,
+            },
+        );
+
+        assert_eq!(prepared.actions.len(), 3);
+        assert!(prepared.actions.iter().any(|action| matches!(
+            action,
+            PreparedSyncAction::CreateIssue(request)
+                if request.project_id == project_id
+                    && request.status_id == status_id
+                    && request.extension_metadata["github"]["issue_number"] == 21
+        )));
+        assert!(prepared.actions.iter().any(|action| matches!(
+            action,
+            PreparedSyncAction::CreateIssue(request)
+                if request.parent_issue_id.is_some()
+                    && request.extension_metadata["github"]["issue_number"] == 22
+        )));
+        assert!(prepared.actions.iter().any(|action| matches!(
+            action,
+            PreparedSyncAction::CreateIssueComment(request)
+                if request.message.contains("vibe-kanban-github-comment-id:2222")
+                    && request.message.contains("@octocat")
+        )));
+    }
+
+    #[test]
+    fn records_unsupported_relation_fetches_as_manual_sync_notes() {
+        let mut issue = simple_gh_issue(31, "Needs GraphQL");
+        issue.unsupported_relations = vec![UnsupportedGitHubRelation {
+            kind: GitHubRelationKind::SubIssues,
+            reason: "GitHub GraphQL subIssues query unavailable in this runtime".into(),
+        }];
+
+        let plan = plan_sync(&[issue], &[]);
+
+        assert!(plan.unsupported.iter().any(|unsupported| matches!(
+            unsupported,
+            UnsupportedSyncItem::GitHubRelation {
+                github_number: 31,
+                kind: GitHubRelationKind::SubIssues,
+                ..
+            }
+        )));
+        assert!(
+            plan.notes
+                .iter()
+                .any(|note| note.contains("needs manual sync"))
+        );
     }
 }

--- a/crates/services/src/services/mod.rs
+++ b/crates/services/src/services/mod.rs
@@ -1,7 +1,6 @@
 pub mod analytics;
 pub mod approvals;
 pub mod auth;
-pub mod github_sync_plan;
 pub mod config;
 pub mod container;
 pub mod diff_stream;
@@ -12,6 +11,7 @@ pub mod file_ranker;
 pub mod file_search;
 pub mod filesystem;
 pub mod filesystem_watcher;
+pub mod github_sync_plan;
 pub mod notification;
 pub mod oauth_credentials;
 pub mod pr_monitor;

--- a/crates/services/src/services/mod.rs
+++ b/crates/services/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod analytics;
 pub mod approvals;
 pub mod auth;
+pub mod github_sync_plan;
 pub mod config;
 pub mod container;
 pub mod diff_stream;

--- a/crates/services/src/services/remote_client.rs
+++ b/crates/services/src/services/remote_client.rs
@@ -4,19 +4,20 @@ use std::time::Duration;
 
 use api_types::{
     AcceptInvitationResponse, AuthMethodsResponse, CreateInvitationRequest,
-    CreateInvitationResponse, CreateIssueAssigneeRequest, CreateIssueRelationshipRequest,
-    CreateIssueRequest, CreateIssueTagRequest, CreateOrganizationRequest,
-    CreateOrganizationResponse, CreateWorkspaceRequest, DeleteResponse, DeleteWorkspaceRequest,
-    GetInvitationResponse, GetOrganizationResponse, HandoffInitRequest, HandoffInitResponse,
-    HandoffRedeemRequest, HandoffRedeemResponse, Issue, IssueAssignee, IssueRelationship, IssueTag,
-    ListAttachmentsResponse, ListInvitationsResponse, ListIssueAssigneesResponse,
-    ListIssueRelationshipsResponse, ListIssueTagsResponse, ListIssuesResponse, ListMembersResponse,
-    ListOrganizationsResponse, ListProjectStatusesResponse, ListProjectsResponse,
-    ListPullRequestsResponse, ListTagsResponse, LocalLoginRequest, LocalLoginResponse,
-    MutationResponse, Organization, ProfileResponse, PullRequest, RevokeInvitationRequest,
-    SearchIssuesRequest, Tag, TokenRefreshRequest, TokenRefreshResponse, UpdateIssueRequest,
-    UpdateMemberRoleRequest, UpdateMemberRoleResponse, UpdateOrganizationRequest,
-    UpdatePullRequestApiRequest, UpdateWorkspaceRequest, UpsertPullRequestRequest, Workspace,
+    CreateInvitationResponse, CreateIssueAssigneeRequest, CreateIssueCommentRequest,
+    CreateIssueRelationshipRequest, CreateIssueRequest, CreateIssueTagRequest,
+    CreateOrganizationRequest, CreateOrganizationResponse, CreateWorkspaceRequest, DeleteResponse,
+    DeleteWorkspaceRequest, GetInvitationResponse, GetOrganizationResponse, HandoffInitRequest,
+    HandoffInitResponse, HandoffRedeemRequest, HandoffRedeemResponse, Issue, IssueAssignee,
+    IssueComment, IssueRelationship, IssueTag, ListAttachmentsResponse, ListInvitationsResponse,
+    ListIssueAssigneesResponse, ListIssueCommentsResponse, ListIssueRelationshipsResponse,
+    ListIssueTagsResponse, ListIssuesResponse, ListMembersResponse, ListOrganizationsResponse,
+    ListProjectStatusesResponse, ListProjectsResponse, ListPullRequestsResponse, ListTagsResponse,
+    LocalLoginRequest, LocalLoginResponse, MutationResponse, Organization, ProfileResponse,
+    PullRequest, RevokeInvitationRequest, SearchIssuesRequest, Tag, TokenRefreshRequest,
+    TokenRefreshResponse, UpdateIssueRequest, UpdateMemberRoleRequest, UpdateMemberRoleResponse,
+    UpdateOrganizationRequest, UpdatePullRequestApiRequest, UpdateWorkspaceRequest,
+    UpsertPullRequestRequest, Workspace,
 };
 use backon::{ExponentialBuilder, Retryable};
 use chrono::Duration as ChronoDuration;
@@ -937,6 +938,25 @@ impl RemoteClient {
     ) -> Result<(), RemoteClientError> {
         self.delete_authed(&format!("/v1/issue_relationships/{relationship_id}"))
             .await
+    }
+
+    // ── Issue Comments ─────────────────────────────────────────────────
+
+    /// Lists comments for an issue.
+    pub async fn list_issue_comments(
+        &self,
+        issue_id: Uuid,
+    ) -> Result<ListIssueCommentsResponse, RemoteClientError> {
+        self.get_authed(&format!("/v1/issue_comments?issue_id={issue_id}"))
+            .await
+    }
+
+    /// Creates a new issue comment.
+    pub async fn create_issue_comment(
+        &self,
+        request: &CreateIssueCommentRequest,
+    ) -> Result<MutationResponse<IssueComment>, RemoteClientError> {
+        self.post_authed("/v1/issue_comments", Some(request)).await
     }
 
     // ── Remote Projects ─────────────────────────────────────────────────


### PR DESCRIPTION
## Scope
This PR is a preparatory BDF-3 slice, not completion of gavinanelson/implication#171. It moves the sync work beyond pure planning by adding remote API execution for the supported Kanban mutations, while the linked issue remains open for default Implication repo wiring, link UI issue listing, GitHub write-back comments, and pre-work GitHub issue comment exposure.

## Summary
- add `execute_prepared_sync` over a `PreparedSyncExecutor`, with a `RemoteClient` implementation for issue create/update, relationship create, and issue comment create
- add local remote issue-comment proxy routes plus `RemoteClient` list/create issue comment methods
- make issue comment API request/response types serializable for remote-client use
- keep tags and unsupported GitHub relations explicit as skipped execution items

## Validation
- `pnpm run generate-types`
- `pnpm run format`
- `cargo test -p services github_sync_plan --lib` (18 tests)
- `cargo check -p services`
- `cargo check -p server`
- `git diff --check origin/main...HEAD`

Tracking: gavinanelson/implication#171 / Vibe Kanban BDF-3
