### PR TITLE
fix: harden Implication autopilot app slice

### DIFF
--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -15,7 +15,8 @@ use db::models::{
 use deployment::Deployment;
 use executors::{
     actions::{
-        ExecutorAction, ExecutorActionType, coding_agent_initial::CodingAgentInitialRequest,
+        ExecutorAction, ExecutorActionType,
+        coding_agent_initial::CodingAgentInitialRequest,
         review::{RepoReviewContext as ExecutorRepoReviewContext, ReviewRequest as ReviewAction},
     },
     executors::{BaseCodingAgent, build_review_prompt},
@@ -209,8 +210,8 @@ async fn start_auto_review(
         .container()
         .ensure_container_exists(&workspace)
         .await?;
-    let context = build_autopilot_review_context(&deployment, &workspace, container_ref.as_str())
-        .await?;
+    let context =
+        build_autopilot_review_context(&deployment, &workspace, container_ref.as_str()).await?;
     let executor_config = default_codex_config();
     let prompt = build_review_prompt(context.as_deref(), Some(REVIEW_PROMPT));
     let action = ExecutorAction::new(
@@ -361,11 +362,11 @@ async fn build_autopilot_review_context(
     let mut contexts = Vec::new();
     for repo in repos {
         let worktree_path = workspace_path.join(&repo.repo.name);
-        if let Ok(base_commit) = deployment.git().get_fork_point(
-            &worktree_path,
-            &repo.target_branch,
-            &workspace.branch,
-        ) {
+        if let Ok(base_commit) =
+            deployment
+                .git()
+                .get_fork_point(&worktree_path, &repo.target_branch, &workspace.branch)
+        {
             contexts.push(ExecutorRepoReviewContext {
                 repo_id: repo.repo.id,
                 repo_name: repo.repo.display_name,
@@ -1041,7 +1042,10 @@ mod tests {
         assert!(is_auto_review_session(Some(
             "Auto review rerun - Codex (medium)"
         )));
-        assert_eq!(auto_review_session_name(false), "Auto review - Codex (medium)");
+        assert_eq!(
+            auto_review_session_name(false),
+            "Auto review - Codex (medium)"
+        );
         assert_eq!(
             auto_review_session_name(true),
             "Auto review rerun - Codex (medium)"
@@ -1049,9 +1053,11 @@ mod tests {
         assert_eq!(review_fix_session_name(), "Review fix - Codex (medium)");
         assert!(is_review_fix_session(Some("Review fix - Codex (medium)")));
         assert!(!is_auto_review_session(Some("Review fix - Codex (medium)")));
-        assert!(!review_fix_session_name()
-            .to_ascii_lowercase()
-            .starts_with("auto review"));
+        assert!(
+            !review_fix_session_name()
+                .to_ascii_lowercase()
+                .starts_with("auto review")
+        );
     }
 
     #[test]

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{future::Future, path::PathBuf};
 
 use axum::{
     Extension, Json, Router,
@@ -156,7 +156,7 @@ async fn start_auto_review(
     State(deployment): State<DeploymentImpl>,
     Json(payload): Json<StartAutopilotReviewRequest>,
 ) -> Result<Json<ApiResponse<AutopilotProcessSummary>>, ApiError> {
-    ensure_implication_autopilot_allowed(&workspace, payload.github_repo_full_name.as_deref())?;
+    ensure_implication_autopilot_allowed(&deployment, &workspace).await?;
 
     if db::models::execution_process::ExecutionProcess::has_running_non_dev_server_processes_for_workspace(
         &deployment.db().pool,
@@ -252,9 +252,9 @@ async fn start_auto_review(
 async fn start_review_fix(
     Extension(workspace): Extension<Workspace>,
     State(deployment): State<DeploymentImpl>,
-    Json(payload): Json<StartAutopilotReviewFixRequest>,
+    Json(_payload): Json<StartAutopilotReviewFixRequest>,
 ) -> Result<Json<ApiResponse<AutopilotProcessSummary>>, ApiError> {
-    ensure_implication_autopilot_allowed(&workspace, payload.github_repo_full_name.as_deref())?;
+    ensure_implication_autopilot_allowed(&deployment, &workspace).await?;
 
     if db::models::execution_process::ExecutionProcess::has_running_non_dev_server_processes_for_workspace(
         &deployment.db().pool,
@@ -378,29 +378,38 @@ async fn build_autopilot_review_context(
     Ok((!contexts.is_empty()).then_some(contexts))
 }
 
-fn ensure_implication_autopilot_allowed(
+async fn ensure_implication_autopilot_allowed(
+    deployment: &DeploymentImpl,
     workspace: &Workspace,
-    github_repo_full_name: Option<&str>,
 ) -> Result<(), ApiError> {
-    if workspace.task_id.is_none() {
+    let client = deployment.remote_client()?;
+    let remote_workspace = client.get_workspace_by_local_id(workspace.id).await?;
+    let Some(issue_id) = remote_workspace.issue_id else {
         return Err(ApiError::Workspace(WorkspaceError::ValidationError(
             "Implication autopilot requires a linked board issue.".to_string(),
         )));
-    }
-
-    let Some(repo) = github_repo_full_name else {
-        return Err(ApiError::Workspace(WorkspaceError::ValidationError(
-            "Implication autopilot requires a linked GitHub issue repo.".to_string(),
-        )));
     };
 
-    if repo.trim().eq_ignore_ascii_case("gavinanelson/implication") {
+    let issue = client.get_issue(issue_id).await?;
+    if is_implication_issue_metadata(&issue.extension_metadata) {
         return Ok(());
     }
 
     Err(ApiError::Workspace(WorkspaceError::ValidationError(
         "Implication autopilot is only enabled for gavinanelson/implication issues.".to_string(),
     )))
+}
+
+fn is_implication_issue_metadata(metadata: &Value) -> bool {
+    let Some(repo) = metadata
+        .get("github_link")
+        .and_then(|link| link.get("repo_full_name"))
+        .and_then(Value::as_str)
+    else {
+        return false;
+    };
+
+    repo.trim().eq_ignore_ascii_case("gavinanelson/implication")
 }
 
 fn auto_review_session_name(rerun: bool) -> String {
@@ -572,34 +581,43 @@ async fn decide_from_review_attempts<'a>(
     deployment: &DeploymentImpl,
     reviews: &[&'a ProcessRow],
 ) -> (AutopilotDecision, Option<String>, Option<&'a ProcessRow>) {
+    decide_from_review_attempts_with_loader(reviews, |process_id| async move {
+        process_agent_text(deployment, process_id).await
+    })
+    .await
+}
+
+async fn decide_from_review_attempts_with_loader<'a, F, Fut>(
+    reviews: &[&'a ProcessRow],
+    mut load_text: F,
+) -> (AutopilotDecision, Option<String>, Option<&'a ProcessRow>)
+where
+    F: FnMut(Uuid) -> Fut,
+    Fut: Future<Output = String>,
+{
     if reviews.is_empty() {
         return (AutopilotDecision::Missing, None, None);
     }
-    if let Some(row) = running_review_attempt(reviews) {
-        return (AutopilotDecision::Running, None, Some(row));
-    }
-
-    for row in reviews {
-        if row.status != ExecutionProcessStatus::Completed || row.exit_code != Some(0) {
-            continue;
-        }
-        let text = process_agent_text(deployment, row.id).await;
-        if text.trim().is_empty() {
-            continue;
-        }
-        let decision = decision_from_text(&text);
-        return (decision, Some(excerpt(&text)), Some(*row));
-    }
 
     let latest = reviews[0];
-    if latest.status == ExecutionProcessStatus::Killed
-        || latest.status == ExecutionProcessStatus::Completed
-    {
-        return (AutopilotDecision::Missing, None, Some(latest));
+    if latest.status == ExecutionProcessStatus::Running {
+        return (AutopilotDecision::Running, None, Some(latest));
     }
+
+    if latest.status == ExecutionProcessStatus::Completed && latest.exit_code == Some(0) {
+        let text = load_text(latest.id).await;
+        if text.trim().is_empty() {
+            return (AutopilotDecision::Failed, None, Some(latest));
+        }
+
+        let decision = decision_from_text(&text);
+        return (decision, Some(excerpt(&text)), Some(latest));
+    }
+
     (AutopilotDecision::Failed, None, Some(latest))
 }
 
+#[cfg(test)]
 fn running_review_attempt<'a>(reviews: &[&'a ProcessRow]) -> Option<&'a ProcessRow> {
     reviews
         .iter()
@@ -1129,6 +1147,73 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn latest_empty_review_attempt_is_failed_instead_of_falling_back_to_older_pass() {
+        let latest_empty = completed_process("Auto review rerun - Codex (medium)", 0);
+        let older_pass = completed_process("Auto review - Codex (medium)", 0);
+        let reviews = vec![&latest_empty, &older_pass];
+
+        let (decision, excerpt, row) =
+            decide_from_review_attempts_with_loader(&reviews, |process_id| async move {
+                if process_id == older_pass.id {
+                    "Decision: pass\nNo blockers.".to_string()
+                } else {
+                    String::new()
+                }
+            })
+            .await;
+
+        assert_eq!(decision, AutopilotDecision::Failed);
+        assert_eq!(excerpt, None);
+        assert_eq!(row.map(|row| row.id), Some(latest_empty.id));
+    }
+
+    #[tokio::test]
+    async fn latest_failed_review_attempt_is_failed_instead_of_falling_back_to_older_pass() {
+        let latest_failed = completed_process("Auto review rerun - Codex (medium)", 1);
+        let older_pass = completed_process("Auto review - Codex (medium)", 0);
+        let reviews = vec![&latest_failed, &older_pass];
+
+        let (decision, excerpt, row) =
+            decide_from_review_attempts_with_loader(&reviews, |process_id| async move {
+                if process_id == older_pass.id {
+                    "Decision: pass\nNo blockers.".to_string()
+                } else {
+                    String::new()
+                }
+            })
+            .await;
+
+        assert_eq!(decision, AutopilotDecision::Failed);
+        assert_eq!(excerpt, None);
+        assert_eq!(row.map(|row| row.id), Some(latest_failed.id));
+    }
+
+    #[test]
+    fn implication_eligibility_reads_repo_from_issue_metadata() {
+        let metadata = serde_json::json!({
+            "github_link": {
+                "repo_full_name": "gavinanelson/implication",
+                "issue_number": 264,
+                "issue_url": "https://github.com/gavinanelson/implication/issues/264"
+            }
+        });
+
+        assert!(is_implication_issue_metadata(&metadata));
+
+        let spoofed_payload_repo = "gavinanelson/implication";
+        let metadata = serde_json::json!({
+            "github_link": {
+                "repo_full_name": "gavinanelson/vibe-kanban",
+                "issue_number": 2,
+                "issue_url": "https://github.com/gavinanelson/vibe-kanban/issues/2"
+            }
+        });
+
+        assert_eq!(spoofed_payload_repo, "gavinanelson/implication");
+        assert!(!is_implication_issue_metadata(&metadata));
+    }
+
     #[test]
     fn action_gating_allows_review_fix_only_after_clean_implementation_and_requested_changes() {
         let implementation = completed_process("Implementation", 0);
@@ -1163,22 +1248,13 @@ mod tests {
 
     #[test]
     fn eligibility_requires_implication_repo_and_linked_issue() {
-        let mut workspace = workspace();
-        assert!(
-            ensure_implication_autopilot_allowed(&workspace, Some("gavinanelson/implication"))
-                .is_ok()
-        );
-
-        assert!(
-            ensure_implication_autopilot_allowed(&workspace, Some("gavinanelson/vibe-kanban"))
-                .is_err()
-        );
-
-        workspace.task_id = None;
-        assert!(
-            ensure_implication_autopilot_allowed(&workspace, Some("gavinanelson/implication"))
-                .is_err()
-        );
+        assert!(!is_implication_issue_metadata(&serde_json::json!({})));
+        assert!(!is_implication_issue_metadata(&serde_json::json!({
+            "github_link": {
+                "issue_number": 264,
+                "issue_url": "https://github.com/gavinanelson/implication/issues/264"
+            }
+        })));
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "backend:lint": "cargo clippy --workspace --all-targets --features qa-mode -- -D warnings && cargo clippy --manifest-path crates/remote/Cargo.toml --all-targets -- -D warnings",
     "backend:format": "cargo fmt --all && cargo fmt --all --manifest-path crates/remote/Cargo.toml",
     "backend:dev": "BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) pnpm run backend:dev:watch",
-    "backend:check": "scripts/run-rust-with-bindgen-env.sh cargo check -p server && scripts/check-remote-self-hosted.sh",
+    "backend:check": "scripts/run-rust-with-bindgen-env.sh cargo check --workspace && scripts/check-remote-self-hosted.sh",
     "backend:dev:watch": "DISABLE_WORKTREE_CLEANUP=1 RUST_LOG=debug scripts/backend-dev.sh",
     "dev:qa": "export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export PREVIEW_PROXY_PORT=$(node scripts/setup-dev-environment.js preview_proxy) && export VK_ALLOWED_ORIGINS=\"http://localhost:${FRONTEND_PORT}\" && export VITE_VK_SHARED_API_BASE=${VK_SHARED_API_BASE:-} && concurrently \"pnpm run backend:dev:watch:qa\" \"pnpm run local-web:dev\"",
     "generate-types": "cargo run --bin generate_types",

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -16,6 +16,7 @@ import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
 import { useIsMobile } from '@/shared/hooks/useIsMobile';
 import { cn } from '@/shared/lib/utils';
 import { useCurrentKanbanRouteState } from '@/shared/hooks/useCurrentKanbanRouteState';
+import { useHostId } from '@/shared/providers/HostIdProvider';
 import {
   useUiPreferencesStore,
   resolveKanbanProjectState,
@@ -185,6 +186,7 @@ export function KanbanContainer() {
   } = useOrgContext();
   const { activeWorkspaces } = useWorkspaceContext();
   const { userId } = useAuth();
+  const effectiveHostId = useHostId();
   const autoReviewTransitionsRef = useRef<Set<string>>(new Set());
   const previousIssueStatusByIdRef = useRef<Map<string, string> | null>(null);
   const [pendingAutoReviewsByIssueId, setPendingAutoReviewsByIssueId] =
@@ -687,13 +689,7 @@ export function KanbanContainer() {
 
   const startAutoReviewForIssue = useCallback(
     async (issueId: string) => {
-      const hostId = routeState.hostId;
-      if (!hostId) {
-        console.warn('Skipping auto-review: no remote host is selected', {
-          issueId,
-        });
-        return;
-      }
+      const hostId = effectiveHostId;
       const workspacesForIssue = getWorkspacesForIssue(issueId).filter(
         (workspace) => !workspace.archived && workspace.local_workspace_id
       );
@@ -789,7 +785,7 @@ export function KanbanContainer() {
         });
       }
     },
-    [getTagObjectsForIssue, getWorkspacesForIssue, routeState.hostId]
+    [effectiveHostId, getTagObjectsForIssue, getWorkspacesForIssue]
   );
 
   useEffect(() => {

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -122,7 +122,7 @@ const areKanbanFiltersEqual = (
   );
 };
 
-const AUTO_REVIEW_SESSION_NAME = 'Auto review — Codex';
+const AUTO_REVIEW_SESSION_NAME = 'Auto review - Codex';
 const AUTO_REVIEW_PROMPT = [
   'Review this workspace as an independent Codex reviewer.',
   'Do not make implementation changes unless they are required to run verification or produce review evidence.',

--- a/packages/web-core/src/shared/lib/implicationAutopilotPresentation.test.ts
+++ b/packages/web-core/src/shared/lib/implicationAutopilotPresentation.test.ts
@@ -7,19 +7,20 @@ import {
 
 describe('implication autopilot presentation', () => {
   it('formats next action tokens as operator-facing copy', () => {
-    expect(getImplicationAutopilotNextActionDisplay('start_auto_review')).toEqual(
-      {
-        label: 'Start auto-review',
-        description: 'Implementation is complete and ready for a Codex review.',
-      }
-    );
+    expect(
+      getImplicationAutopilotNextActionDisplay('start_auto_review')
+    ).toEqual({
+      label: 'Start auto-review',
+      description: 'Implementation is complete and ready for a Codex review.',
+    });
 
-    expect(getImplicationAutopilotNextActionDisplay('wait_for_review_fix')).toEqual(
-      {
-        label: 'Fix running',
-        description: 'Requested changes are being handled by a Codex fix session.',
-      }
-    );
+    expect(
+      getImplicationAutopilotNextActionDisplay('wait_for_review_fix')
+    ).toEqual({
+      label: 'Fix running',
+      description:
+        'Requested changes are being handled by a Codex fix session.',
+    });
 
     expect(getImplicationAutopilotNextActionDisplay('ready_for_merge')).toEqual(
       {

--- a/packages/web-core/src/shared/lib/implicationAutopilotPresentation.ts
+++ b/packages/web-core/src/shared/lib/implicationAutopilotPresentation.ts
@@ -35,7 +35,8 @@ const NEXT_ACTION_DISPLAY: Record<
   },
   ready_for_merge: {
     label: 'Ready for merge',
-    description: 'Auto-review passed; open the PR and complete the merge handoff.',
+    description:
+      'Auto-review passed; open the PR and complete the merge handoff.',
   },
   merge_wait: {
     label: 'Merge in progress',

--- a/packages/web-core/src/shared/providers/HostIdProvider.tsx
+++ b/packages/web-core/src/shared/providers/HostIdProvider.tsx
@@ -1,45 +1,12 @@
 import {
   createContext,
   useContext,
-  useEffect,
   useLayoutEffect,
   useMemo,
-  useState,
   type ReactNode,
 } from 'react';
 import { useCurrentAppDestination } from '@/shared/hooks/useCurrentAppDestination';
 import { getDestinationHostId } from '@/shared/lib/routes/appNavigation';
-import {
-  listPairedRelayHosts,
-  subscribeRelayPairingChanges,
-} from '@/shared/lib/relayPairingStorage';
-
-type BackendPairedRelayHost = {
-  host_id: string;
-  host_name?: string;
-  paired_at?: string;
-};
-
-async function listBackendPairedRelayHosts(): Promise<
-  BackendPairedRelayHost[]
-> {
-  const response = await fetch('/api/relay-auth/client/hosts', {
-    headers: { Accept: 'application/json' },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to list paired relay hosts: ${response.status}`);
-  }
-
-  const body = (await response.json()) as {
-    success?: boolean;
-    data?: { hosts?: BackendPairedRelayHost[] };
-  };
-
-  return body.success === true && Array.isArray(body.data?.hosts)
-    ? body.data.hosts
-    : [];
-}
 
 // Module-level getter so the API transport can read the hostId outside React
 let _hostId: string | null = null;
@@ -71,54 +38,10 @@ export function HostIdProvider({ children }: { children: ReactNode }) {
     () => getDestinationHostId(destination),
     [destination]
   );
-  const [singlePairedHostId, setSinglePairedHostId] = useState<string | null>(
-    null
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const refreshSinglePairedHost = async () => {
-      try {
-        const [indexedDbHosts, backendHosts] = await Promise.allSettled([
-          listPairedRelayHosts(),
-          listBackendPairedRelayHosts(),
-        ]);
-        if (cancelled) return;
-
-        const hostIds = new Set<string>();
-        if (indexedDbHosts.status === 'fulfilled') {
-          for (const host of indexedDbHosts.value) {
-            hostIds.add(host.host_id);
-          }
-        }
-        if (backendHosts.status === 'fulfilled') {
-          for (const host of backendHosts.value) {
-            hostIds.add(host.host_id);
-          }
-        }
-
-        setSinglePairedHostId(hostIds.size === 1 ? [...hostIds][0] : null);
-      } catch (error) {
-        if (!cancelled) {
-          console.warn('Failed to resolve paired relay hosts', error);
-          setSinglePairedHostId(null);
-        }
-      }
-    };
-
-    void refreshSinglePairedHost();
-    const unsubscribe = subscribeRelayPairingChanges(() => {
-      void refreshSinglePairedHost();
-    });
-
-    return () => {
-      cancelled = true;
-      unsubscribe();
-    };
-  }, []);
-
-  const hostId = routeHostId ?? singlePairedHostId;
+  // Do not globally fall back to the only paired host. Host-aware calls on local
+  // routes must stay local unless the current route or a scoped provider
+  // explicitly supplies a host id.
+  const hostId = routeHostId;
 
   useLayoutEffect(() => {
     _hostId = hostId;


### PR DESCRIPTION
## Summary
- Fixes post-review blockers in the Implication autopilot app slice after PR #2 merged.
- Keeps host-aware routing scoped to explicit route/provider host ids instead of globally redirecting local routes to the only paired host.
- Aligns board-triggered auto-review session naming with backend status classification and teaches the classifier to accept hyphen/em-dash review session names.
- Ensures backend Implication autopilot eligibility is checked against linked issue metadata, not client-supplied payload, and ensures latest failed/empty review attempts cannot be masked by older passes.

## Validation
- [x] `pnpm run web-core:check`
- [x] `pnpm run local-web:check`
- [x] `cargo test -p server implication_autopilot::tests --no-default-features` — 17 passed