### PR TITLE
fix: finish autopilot generated types and scoped review trigger

### DIFF
--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -872,25 +872,6 @@ export function KanbanContainer() {
       pendingIssueIds: pendingAutoReviewIssueIdsRef.current,
     });
 
-    const waitingForWorkspaceContext = reviewIssueIds.some((issueId) => {
-      const linkedWorkspaces = getWorkspacesForIssue(issueId).filter(
-        (workspace) => !workspace.archived && !!workspace.local_workspace_id
-      );
-
-      return (
-        linkedWorkspaces.length > 0 &&
-        !getAutoReviewLocalWorkspaceId(linkedWorkspaces, localWorkspacesById)
-      );
-    });
-
-    if (waitingForWorkspaceContext) {
-      for (const issueId of reviewIssueIds) {
-        pendingAutoReviewIssueIdsRef.current.add(issueId);
-      }
-      previousIssueStatusByIdRef.current = currentStatuses;
-      return;
-    }
-
     previousIssueStatusByIdRef.current = currentStatuses;
 
     for (const issueId of reviewIssueIds) {

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -86,6 +86,7 @@ import {
   isReviewStatusName,
   type PendingAutoReview,
 } from '@/shared/lib/autoReviewStatus';
+import { getAutoReviewLocalWorkspaceId } from '@/shared/lib/autoReviewWorkspace';
 
 const areStringSetsEqual = (left: string[], right: string[]): boolean => {
   if (left.length !== right.length) {
@@ -690,11 +691,10 @@ export function KanbanContainer() {
   const startAutoReviewForIssue = useCallback(
     async (issueId: string) => {
       const hostId = effectiveHostId;
-      const workspacesForIssue = getWorkspacesForIssue(issueId).filter(
-        (workspace) => !workspace.archived && workspace.local_workspace_id
+      const localWorkspaceId = getAutoReviewLocalWorkspaceId(
+        getWorkspacesForIssue(issueId),
+        localWorkspacesById
       );
-      const workspace = workspacesForIssue[0];
-      const localWorkspaceId = workspace?.local_workspace_id;
       if (!localWorkspaceId) {
         console.warn(
           'Skipping auto-review: issue has no linked local workspace',
@@ -785,7 +785,12 @@ export function KanbanContainer() {
         });
       }
     },
-    [effectiveHostId, getTagObjectsForIssue, getWorkspacesForIssue]
+    [
+      effectiveHostId,
+      getTagObjectsForIssue,
+      getWorkspacesForIssue,
+      localWorkspacesById,
+    ]
   );
 
   useEffect(() => {

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -847,11 +847,11 @@ export function KanbanContainer() {
       issues.map((issue) => [issue.id, issue.status_id])
     );
     const previousStatuses = previousIssueStatusByIdRef.current;
-    previousIssueStatusByIdRef.current = currentStatuses;
 
     // Seed the previous-status map on first load without firing reviews for
     // cards that were already waiting in review before this client mounted.
     if (!previousStatuses) {
+      previousIssueStatusByIdRef.current = currentStatuses;
       return;
     }
 
@@ -862,20 +862,47 @@ export function KanbanContainer() {
     );
 
     if (reviewStatusIds.size === 0) {
+      previousIssueStatusByIdRef.current = currentStatuses;
       return;
     }
 
-    for (const issue of issues) {
+    const reviewTransitions = issues.filter((issue) => {
       const previousStatusId = previousStatuses.get(issue.id);
-      if (
-        previousStatusId &&
+      return (
+        !!previousStatusId &&
         previousStatusId !== issue.status_id &&
         reviewStatusIds.has(issue.status_id)
-      ) {
-        void startAutoReviewForIssue(issue.id);
-      }
+      );
+    });
+
+    const waitingForWorkspaceContext = reviewTransitions.some((issue) => {
+      const linkedWorkspaces = getWorkspacesForIssue(issue.id).filter(
+        (workspace) => !workspace.archived && !!workspace.local_workspace_id
+      );
+
+      return (
+        linkedWorkspaces.length > 0 &&
+        !getAutoReviewLocalWorkspaceId(linkedWorkspaces, localWorkspacesById)
+      );
+    });
+
+    if (waitingForWorkspaceContext) {
+      return;
     }
-  }, [issues, statuses, startAutoReviewForIssue, isWorkspacesListLoading]);
+
+    previousIssueStatusByIdRef.current = currentStatuses;
+
+    for (const issue of reviewTransitions) {
+      void startAutoReviewForIssue(issue.id);
+    }
+  }, [
+    getWorkspacesForIssue,
+    issues,
+    statuses,
+    startAutoReviewForIssue,
+    isWorkspacesListLoading,
+    localWorkspacesById,
+  ]);
 
   // Calculate sort_order based on column index and issue position
   // Formula: 1000 * [COLUMN_INDEX] + [ISSUE_INDEX] (both 1-based)

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -86,6 +86,7 @@ import {
   isReviewStatusName,
   type PendingAutoReview,
 } from '@/shared/lib/autoReviewStatus';
+import { getAutoReviewTransitionIssueIds } from '@/shared/lib/autoReviewTransitions';
 import { getAutoReviewLocalWorkspaceId } from '@/shared/lib/autoReviewWorkspace';
 
 const areStringSetsEqual = (left: string[], right: string[]): boolean => {
@@ -190,6 +191,7 @@ export function KanbanContainer() {
   const effectiveHostId = useHostId();
   const autoReviewTransitionsRef = useRef<Set<string>>(new Set());
   const previousIssueStatusByIdRef = useRef<Map<string, string> | null>(null);
+  const pendingAutoReviewIssueIdsRef = useRef<Set<string>>(new Set());
   const [pendingAutoReviewsByIssueId, setPendingAutoReviewsByIssueId] =
     useState<Record<string, PendingAutoReview>>({});
 
@@ -691,6 +693,7 @@ export function KanbanContainer() {
   const startAutoReviewForIssue = useCallback(
     async (issueId: string) => {
       if (isWorkspacesListLoading) {
+        pendingAutoReviewIssueIdsRef.current.add(issueId);
         return;
       }
 
@@ -839,10 +842,6 @@ export function KanbanContainer() {
   }, [localWorkspacesById]);
 
   useEffect(() => {
-    if (isWorkspacesListLoading) {
-      return;
-    }
-
     const currentStatuses = new Map(
       issues.map((issue) => [issue.id, issue.status_id])
     );
@@ -866,17 +865,15 @@ export function KanbanContainer() {
       return;
     }
 
-    const reviewTransitions = issues.filter((issue) => {
-      const previousStatusId = previousStatuses.get(issue.id);
-      return (
-        !!previousStatusId &&
-        previousStatusId !== issue.status_id &&
-        reviewStatusIds.has(issue.status_id)
-      );
+    const reviewIssueIds = getAutoReviewTransitionIssueIds({
+      issues,
+      previousStatusByIssueId: previousStatuses,
+      reviewStatusIds,
+      pendingIssueIds: pendingAutoReviewIssueIdsRef.current,
     });
 
-    const waitingForWorkspaceContext = reviewTransitions.some((issue) => {
-      const linkedWorkspaces = getWorkspacesForIssue(issue.id).filter(
+    const waitingForWorkspaceContext = reviewIssueIds.some((issueId) => {
+      const linkedWorkspaces = getWorkspacesForIssue(issueId).filter(
         (workspace) => !workspace.archived && !!workspace.local_workspace_id
       );
 
@@ -887,13 +884,18 @@ export function KanbanContainer() {
     });
 
     if (waitingForWorkspaceContext) {
+      for (const issueId of reviewIssueIds) {
+        pendingAutoReviewIssueIdsRef.current.add(issueId);
+      }
+      previousIssueStatusByIdRef.current = currentStatuses;
       return;
     }
 
     previousIssueStatusByIdRef.current = currentStatuses;
 
-    for (const issue of reviewTransitions) {
-      void startAutoReviewForIssue(issue.id);
+    for (const issueId of reviewIssueIds) {
+      pendingAutoReviewIssueIdsRef.current.delete(issueId);
+      void startAutoReviewForIssue(issueId);
     }
   }, [
     getWorkspacesForIssue,

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -185,7 +185,7 @@ export function KanbanContainer() {
     membersWithProfilesById,
     isLoading: orgLoading,
   } = useOrgContext();
-  const { activeWorkspaces } = useWorkspaceContext();
+  const { activeWorkspaces, isWorkspacesListLoading } = useWorkspaceContext();
   const { userId } = useAuth();
   const effectiveHostId = useHostId();
   const autoReviewTransitionsRef = useRef<Set<string>>(new Set());
@@ -690,6 +690,10 @@ export function KanbanContainer() {
 
   const startAutoReviewForIssue = useCallback(
     async (issueId: string) => {
+      if (isWorkspacesListLoading) {
+        return;
+      }
+
       const hostId = effectiveHostId;
       const localWorkspaceId = getAutoReviewLocalWorkspaceId(
         getWorkspacesForIssue(issueId),
@@ -789,6 +793,7 @@ export function KanbanContainer() {
       effectiveHostId,
       getTagObjectsForIssue,
       getWorkspacesForIssue,
+      isWorkspacesListLoading,
       localWorkspacesById,
     ]
   );

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -839,6 +839,10 @@ export function KanbanContainer() {
   }, [localWorkspacesById]);
 
   useEffect(() => {
+    if (isWorkspacesListLoading) {
+      return;
+    }
+
     const currentStatuses = new Map(
       issues.map((issue) => [issue.id, issue.status_id])
     );
@@ -871,7 +875,7 @@ export function KanbanContainer() {
         void startAutoReviewForIssue(issue.id);
       }
     }
-  }, [issues, statuses, startAutoReviewForIssue]);
+  }, [issues, statuses, startAutoReviewForIssue, isWorkspacesListLoading]);
 
   // Calculate sort_order based on column index and issue position
   // Formula: 1000 * [COLUMN_INDEX] + [ISSUE_INDEX] (both 1-based)

--- a/packages/web-core/src/shared/lib/autoReviewTransitions.test.ts
+++ b/packages/web-core/src/shared/lib/autoReviewTransitions.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import { deepEqual } from 'node:assert/strict';
+
+import { getAutoReviewTransitionIssueIds } from './autoReviewTransitions.ts';
+
+describe('getAutoReviewTransitionIssueIds', () => {
+  it('keeps review transitions observed while loading available after loading finishes', () => {
+    const reviewStatusIds = new Set(['review']);
+    const pendingIssueIds = new Set<string>();
+
+    const loadingTransitionIds = getAutoReviewTransitionIssueIds({
+      issues: [{ id: 'issue-1', status_id: 'review' }],
+      previousStatusByIssueId: new Map([['issue-1', 'todo']]),
+      reviewStatusIds,
+      pendingIssueIds,
+    });
+
+    for (const issueId of loadingTransitionIds) {
+      pendingIssueIds.add(issueId);
+    }
+
+    deepEqual(loadingTransitionIds, ['issue-1']);
+    deepEqual(
+      getAutoReviewTransitionIssueIds({
+        issues: [{ id: 'issue-1', status_id: 'review' }],
+        previousStatusByIssueId: new Map([['issue-1', 'review']]),
+        reviewStatusIds,
+        pendingIssueIds,
+      }),
+      ['issue-1']
+    );
+  });
+
+  it('does not keep a pending transition if the issue leaves review before loading finishes', () => {
+    deepEqual(
+      getAutoReviewTransitionIssueIds({
+        issues: [{ id: 'issue-1', status_id: 'todo' }],
+        previousStatusByIssueId: new Map([['issue-1', 'review']]),
+        reviewStatusIds: new Set(['review']),
+        pendingIssueIds: new Set(['issue-1']),
+      }),
+      []
+    );
+  });
+});

--- a/packages/web-core/src/shared/lib/autoReviewTransitions.ts
+++ b/packages/web-core/src/shared/lib/autoReviewTransitions.ts
@@ -1,0 +1,41 @@
+export type AutoReviewTransitionIssue = {
+  id: string;
+  status_id?: string | null;
+};
+
+export type GetAutoReviewTransitionIssueIdsInput = {
+  issues: AutoReviewTransitionIssue[];
+  previousStatusByIssueId: ReadonlyMap<string, string>;
+  reviewStatusIds: ReadonlySet<string>;
+  pendingIssueIds?: ReadonlySet<string>;
+};
+
+export const getAutoReviewTransitionIssueIds = ({
+  issues,
+  previousStatusByIssueId,
+  reviewStatusIds,
+  pendingIssueIds,
+}: GetAutoReviewTransitionIssueIdsInput): string[] => {
+  const issueIds = new Set<string>();
+
+  for (const issue of issues) {
+    const isInReview =
+      !!issue.status_id && reviewStatusIds.has(issue.status_id);
+
+    if (!isInReview) {
+      continue;
+    }
+
+    if (pendingIssueIds?.has(issue.id)) {
+      issueIds.add(issue.id);
+      continue;
+    }
+
+    const previousStatusId = previousStatusByIssueId.get(issue.id);
+    if (previousStatusId && previousStatusId !== issue.status_id) {
+      issueIds.add(issue.id);
+    }
+  }
+
+  return [...issueIds];
+};

--- a/packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts
+++ b/packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import { equal } from 'node:assert/strict';
+
+import { getAutoReviewLocalWorkspaceId } from './autoReviewWorkspace';
+
+describe('getAutoReviewLocalWorkspaceId', () => {
+  it('selects the first non-archived linked workspace in the local context', () => {
+    equal(
+      getAutoReviewLocalWorkspaceId(
+        [
+          {
+            archived: false,
+            local_workspace_id: 'remote-workspace',
+          },
+          {
+            archived: false,
+            local_workspace_id: 'local-workspace',
+          },
+        ],
+        new Map([['local-workspace', {}]])
+      ),
+      'local-workspace'
+    );
+  });
+
+  it('does not select archived or remote-only linked workspaces', () => {
+    equal(
+      getAutoReviewLocalWorkspaceId(
+        [
+          {
+            archived: false,
+            local_workspace_id: 'remote-workspace',
+          },
+          {
+            archived: true,
+            local_workspace_id: 'local-workspace',
+          },
+        ],
+        new Map([['local-workspace', {}]])
+      ),
+      null
+    );
+  });
+});

--- a/packages/web-core/src/shared/lib/autoReviewWorkspace.ts
+++ b/packages/web-core/src/shared/lib/autoReviewWorkspace.ts
@@ -1,0 +1,18 @@
+export type AutoReviewLinkedWorkspace = {
+  archived?: boolean | null;
+  local_workspace_id?: string | null;
+};
+
+export const getAutoReviewLocalWorkspaceId = (
+  workspaces: AutoReviewLinkedWorkspace[],
+  localWorkspacesById: ReadonlyMap<string, unknown>
+): string | null => {
+  const workspace = workspaces.find(
+    (workspace) =>
+      !workspace.archived &&
+      !!workspace.local_workspace_id &&
+      localWorkspacesById.has(workspace.local_workspace_id)
+  );
+
+  return workspace?.local_workspace_id ?? null;
+};

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -270,7 +270,9 @@ export type AutopilotProcessSummary = { id: string, session_id: string, session_
 
 export type ImplicationAutopilotStatus = { workspace_id: string, workspace_name: string | null, implementation_state: string, auto_review_state: AutopilotDecision, latest_review_decision: AutopilotDecision, latest_review_excerpt: string | null, review_fix_state: string, pr_merge_state: string, next_action: AutopilotNextAction, blocker: string | null, implementation_process: AutopilotProcessSummary | null, auto_review_process: AutopilotProcessSummary | null, review_fix_process: AutopilotProcessSummary | null, default_model: string, default_reasoning: string, daemonized: boolean, };
 
-export type StartAutopilotReviewRequest = { rerun: boolean, };
+export type StartAutopilotReviewRequest = { rerun: boolean, github_repo_full_name: string | null, };
+
+export type StartAutopilotReviewFixRequest = { github_repo_full_name: string | null, };
 
 export type TagSearchParams = { search: string | null, };
 


### PR DESCRIPTION
## Summary
- Regenerate shared TypeScript types for the merged Implication autopilot request payloads
- Scope the automatic review trigger to linked workspaces visible in the current local/host context so null-host local routes still work while remote workspaces do not misroute
- Add a small workspace-selection regression helper/test

## Validation
- `pnpm --filter @vibe/web-core run check`
- `pnpm --filter @vibe/ui run check`
- `pnpm run generate-types`
- `git diff --exit-code shared/types.ts`
