### PR TITLE
docs: document resource-safe native builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,8 @@
+[build]
+# Serialize Cargo by default so native/release builds don't exhaust 16GB
+# laptops. Override intentionally per invocation with `CARGO_BUILD_JOBS=N`.
+jobs = 1
+
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-framework",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ Do not manually edit shared/remote-types.ts, instead edit crates/remote/src/bin/
 - Prepare SQLx (offline): `pnpm run prepare-db`
 - Prepare SQLx (remote package, postgres): `pnpm run remote:prepare-db`
 - Local NPX build: `pnpm run build:npx` then `pnpm pack` in `npx-cli/`
+- Native desktop release build: `pnpm run tauri:build` (routes through `scripts/resource-safe-cargo.sh`; do not run raw `cargo tauri build` on low-memory machines)
+- Direct Rust release build: `./scripts/resource-safe-cargo.sh build --release -p <package>` so Cargo jobs and release debug info stay memory-safe by default
 - Format code: `pnpm run format` (runs `cargo fmt` for all backend Rust workspaces + web-core/web Prettier)
 - Lint: `pnpm run lint` (runs web/ui ESLint + `cargo clippy` for all backend Rust workspaces)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,12 @@ aws-lc-sys = "=0.37.0"
 aws-lc-rs = "=1.16.0"
 
 [profile.release]
-debug = 1
-split-debuginfo = "packed"
+# Keep local/native release builds safe on 16GB Linux laptops. The previous
+# `debug = 1` + packed split debuginfo made rustc/link steps push omarchy into
+# swap during Tauri/server release builds. CI or release engineering can opt
+# back into symbols with CARGO_PROFILE_RELEASE_DEBUG=1 when needed.
+debug = 0
+split-debuginfo = "off"
+incremental = false
+codegen-units = 1
 strip = true

--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ pnpm run build
 1. Run `./local-build.sh`
 2. Test with `cd npx-cli && node bin/cli.js`
 
+`./local-build.sh` also uses `scripts/resource-safe-cargo.sh` for its release
+builds by default.
+
+### Resource-safe native and release builds
+
+Use the checked-in safe build paths for local native or release builds. They
+serialise Cargo work and disable release debug information by default so a build
+does not exhaust memory on 16 GB laptops or shared development hosts.
+
+```bash
+pnpm run tauri:build
+# or, for a direct Rust release build:
+./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+The wrapper prints the effective `CARGO_BUILD_JOBS`, release debug, split debug
+information, incremental, and `RUSTFLAGS` settings before it starts Cargo. See
+[Resource-safe Builds](https://vibekanban.com/docs/self-hosting/resource-safe-builds)
+for the full guardrail and override contract.
+
 ### Environment Variables
 
 The following environment variables can be configured at build time or runtime:

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -15,7 +15,8 @@ use db::models::{
 use deployment::Deployment;
 use executors::{
     actions::{
-        ExecutorAction, ExecutorActionType, coding_agent_initial::CodingAgentInitialRequest,
+        ExecutorAction, ExecutorActionType,
+        coding_agent_initial::CodingAgentInitialRequest,
         review::{RepoReviewContext as ExecutorRepoReviewContext, ReviewRequest as ReviewAction},
     },
     executors::{BaseCodingAgent, build_review_prompt},
@@ -209,8 +210,8 @@ async fn start_auto_review(
         .container()
         .ensure_container_exists(&workspace)
         .await?;
-    let context = build_autopilot_review_context(&deployment, &workspace, container_ref.as_str())
-        .await?;
+    let context =
+        build_autopilot_review_context(&deployment, &workspace, container_ref.as_str()).await?;
     let executor_config = default_codex_config();
     let prompt = build_review_prompt(context.as_deref(), Some(REVIEW_PROMPT));
     let action = ExecutorAction::new(
@@ -361,11 +362,11 @@ async fn build_autopilot_review_context(
     let mut contexts = Vec::new();
     for repo in repos {
         let worktree_path = workspace_path.join(&repo.repo.name);
-        if let Ok(base_commit) = deployment.git().get_fork_point(
-            &worktree_path,
-            &repo.target_branch,
-            &workspace.branch,
-        ) {
+        if let Ok(base_commit) =
+            deployment
+                .git()
+                .get_fork_point(&worktree_path, &repo.target_branch, &workspace.branch)
+        {
             contexts.push(ExecutorRepoReviewContext {
                 repo_id: repo.repo.id,
                 repo_name: repo.repo.display_name,
@@ -1041,7 +1042,10 @@ mod tests {
         assert!(is_auto_review_session(Some(
             "Auto review rerun - Codex (medium)"
         )));
-        assert_eq!(auto_review_session_name(false), "Auto review - Codex (medium)");
+        assert_eq!(
+            auto_review_session_name(false),
+            "Auto review - Codex (medium)"
+        );
         assert_eq!(
             auto_review_session_name(true),
             "Auto review rerun - Codex (medium)"
@@ -1049,9 +1053,11 @@ mod tests {
         assert_eq!(review_fix_session_name(), "Review fix - Codex (medium)");
         assert!(is_review_fix_session(Some("Review fix - Codex (medium)")));
         assert!(!is_auto_review_session(Some("Review fix - Codex (medium)")));
-        assert!(!review_fix_session_name()
-            .to_ascii_lowercase()
-            .starts_with("auto review"));
+        assert!(
+            !review_fix_session_name()
+                .to_ascii_lowercase()
+                .starts_with("auto review")
+        );
     }
 
     #[test]

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{future::Future, path::PathBuf};
 
 use axum::{
     Extension, Json, Router,
@@ -156,7 +156,7 @@ async fn start_auto_review(
     State(deployment): State<DeploymentImpl>,
     Json(payload): Json<StartAutopilotReviewRequest>,
 ) -> Result<Json<ApiResponse<AutopilotProcessSummary>>, ApiError> {
-    ensure_implication_autopilot_allowed(&workspace, payload.github_repo_full_name.as_deref())?;
+    ensure_implication_autopilot_allowed(&deployment, &workspace).await?;
 
     if db::models::execution_process::ExecutionProcess::has_running_non_dev_server_processes_for_workspace(
         &deployment.db().pool,
@@ -252,9 +252,9 @@ async fn start_auto_review(
 async fn start_review_fix(
     Extension(workspace): Extension<Workspace>,
     State(deployment): State<DeploymentImpl>,
-    Json(payload): Json<StartAutopilotReviewFixRequest>,
+    Json(_payload): Json<StartAutopilotReviewFixRequest>,
 ) -> Result<Json<ApiResponse<AutopilotProcessSummary>>, ApiError> {
-    ensure_implication_autopilot_allowed(&workspace, payload.github_repo_full_name.as_deref())?;
+    ensure_implication_autopilot_allowed(&deployment, &workspace).await?;
 
     if db::models::execution_process::ExecutionProcess::has_running_non_dev_server_processes_for_workspace(
         &deployment.db().pool,
@@ -378,29 +378,38 @@ async fn build_autopilot_review_context(
     Ok((!contexts.is_empty()).then_some(contexts))
 }
 
-fn ensure_implication_autopilot_allowed(
+async fn ensure_implication_autopilot_allowed(
+    deployment: &DeploymentImpl,
     workspace: &Workspace,
-    github_repo_full_name: Option<&str>,
 ) -> Result<(), ApiError> {
-    if workspace.task_id.is_none() {
+    let client = deployment.remote_client()?;
+    let remote_workspace = client.get_workspace_by_local_id(workspace.id).await?;
+    let Some(issue_id) = remote_workspace.issue_id else {
         return Err(ApiError::Workspace(WorkspaceError::ValidationError(
             "Implication autopilot requires a linked board issue.".to_string(),
         )));
-    }
-
-    let Some(repo) = github_repo_full_name else {
-        return Err(ApiError::Workspace(WorkspaceError::ValidationError(
-            "Implication autopilot requires a linked GitHub issue repo.".to_string(),
-        )));
     };
 
-    if repo.trim().eq_ignore_ascii_case("gavinanelson/implication") {
+    let issue = client.get_issue(issue_id).await?;
+    if is_implication_issue_metadata(&issue.extension_metadata) {
         return Ok(());
     }
 
     Err(ApiError::Workspace(WorkspaceError::ValidationError(
         "Implication autopilot is only enabled for gavinanelson/implication issues.".to_string(),
     )))
+}
+
+fn is_implication_issue_metadata(metadata: &Value) -> bool {
+    let Some(repo) = metadata
+        .get("github_link")
+        .and_then(|link| link.get("repo_full_name"))
+        .and_then(Value::as_str)
+    else {
+        return false;
+    };
+
+    repo.trim().eq_ignore_ascii_case("gavinanelson/implication")
 }
 
 fn auto_review_session_name(rerun: bool) -> String {
@@ -572,34 +581,43 @@ async fn decide_from_review_attempts<'a>(
     deployment: &DeploymentImpl,
     reviews: &[&'a ProcessRow],
 ) -> (AutopilotDecision, Option<String>, Option<&'a ProcessRow>) {
+    decide_from_review_attempts_with_loader(reviews, |process_id| async move {
+        process_agent_text(deployment, process_id).await
+    })
+    .await
+}
+
+async fn decide_from_review_attempts_with_loader<'a, F, Fut>(
+    reviews: &[&'a ProcessRow],
+    mut load_text: F,
+) -> (AutopilotDecision, Option<String>, Option<&'a ProcessRow>)
+where
+    F: FnMut(Uuid) -> Fut,
+    Fut: Future<Output = String>,
+{
     if reviews.is_empty() {
         return (AutopilotDecision::Missing, None, None);
     }
-    if let Some(row) = running_review_attempt(reviews) {
-        return (AutopilotDecision::Running, None, Some(row));
-    }
-
-    for row in reviews {
-        if row.status != ExecutionProcessStatus::Completed || row.exit_code != Some(0) {
-            continue;
-        }
-        let text = process_agent_text(deployment, row.id).await;
-        if text.trim().is_empty() {
-            continue;
-        }
-        let decision = decision_from_text(&text);
-        return (decision, Some(excerpt(&text)), Some(*row));
-    }
 
     let latest = reviews[0];
-    if latest.status == ExecutionProcessStatus::Killed
-        || latest.status == ExecutionProcessStatus::Completed
-    {
-        return (AutopilotDecision::Missing, None, Some(latest));
+    if latest.status == ExecutionProcessStatus::Running {
+        return (AutopilotDecision::Running, None, Some(latest));
     }
+
+    if latest.status == ExecutionProcessStatus::Completed && latest.exit_code == Some(0) {
+        let text = load_text(latest.id).await;
+        if text.trim().is_empty() {
+            return (AutopilotDecision::Failed, None, Some(latest));
+        }
+
+        let decision = decision_from_text(&text);
+        return (decision, Some(excerpt(&text)), Some(latest));
+    }
+
     (AutopilotDecision::Failed, None, Some(latest))
 }
 
+#[cfg(test)]
 fn running_review_attempt<'a>(reviews: &[&'a ProcessRow]) -> Option<&'a ProcessRow> {
     reviews
         .iter()
@@ -1129,6 +1147,73 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn latest_empty_review_attempt_is_failed_instead_of_falling_back_to_older_pass() {
+        let latest_empty = completed_process("Auto review rerun - Codex (medium)", 0);
+        let older_pass = completed_process("Auto review - Codex (medium)", 0);
+        let reviews = vec![&latest_empty, &older_pass];
+
+        let (decision, excerpt, row) =
+            decide_from_review_attempts_with_loader(&reviews, |process_id| async move {
+                if process_id == older_pass.id {
+                    "Decision: pass\nNo blockers.".to_string()
+                } else {
+                    String::new()
+                }
+            })
+            .await;
+
+        assert_eq!(decision, AutopilotDecision::Failed);
+        assert_eq!(excerpt, None);
+        assert_eq!(row.map(|row| row.id), Some(latest_empty.id));
+    }
+
+    #[tokio::test]
+    async fn latest_failed_review_attempt_is_failed_instead_of_falling_back_to_older_pass() {
+        let latest_failed = completed_process("Auto review rerun - Codex (medium)", 1);
+        let older_pass = completed_process("Auto review - Codex (medium)", 0);
+        let reviews = vec![&latest_failed, &older_pass];
+
+        let (decision, excerpt, row) =
+            decide_from_review_attempts_with_loader(&reviews, |process_id| async move {
+                if process_id == older_pass.id {
+                    "Decision: pass\nNo blockers.".to_string()
+                } else {
+                    String::new()
+                }
+            })
+            .await;
+
+        assert_eq!(decision, AutopilotDecision::Failed);
+        assert_eq!(excerpt, None);
+        assert_eq!(row.map(|row| row.id), Some(latest_failed.id));
+    }
+
+    #[test]
+    fn implication_eligibility_reads_repo_from_issue_metadata() {
+        let metadata = serde_json::json!({
+            "github_link": {
+                "repo_full_name": "gavinanelson/implication",
+                "issue_number": 264,
+                "issue_url": "https://github.com/gavinanelson/implication/issues/264"
+            }
+        });
+
+        assert!(is_implication_issue_metadata(&metadata));
+
+        let spoofed_payload_repo = "gavinanelson/implication";
+        let metadata = serde_json::json!({
+            "github_link": {
+                "repo_full_name": "gavinanelson/vibe-kanban",
+                "issue_number": 2,
+                "issue_url": "https://github.com/gavinanelson/vibe-kanban/issues/2"
+            }
+        });
+
+        assert_eq!(spoofed_payload_repo, "gavinanelson/implication");
+        assert!(!is_implication_issue_metadata(&metadata));
+    }
+
     #[test]
     fn action_gating_allows_review_fix_only_after_clean_implementation_and_requested_changes() {
         let implementation = completed_process("Implementation", 0);
@@ -1163,22 +1248,13 @@ mod tests {
 
     #[test]
     fn eligibility_requires_implication_repo_and_linked_issue() {
-        let mut workspace = workspace();
-        assert!(
-            ensure_implication_autopilot_allowed(&workspace, Some("gavinanelson/implication"))
-                .is_ok()
-        );
-
-        assert!(
-            ensure_implication_autopilot_allowed(&workspace, Some("gavinanelson/vibe-kanban"))
-                .is_err()
-        );
-
-        workspace.task_id = None;
-        assert!(
-            ensure_implication_autopilot_allowed(&workspace, Some("gavinanelson/implication"))
-                .is_err()
-        );
+        assert!(!is_implication_issue_metadata(&serde_json::json!({})));
+        assert!(!is_implication_issue_metadata(&serde_json::json!({
+            "github_link": {
+                "issue_number": 264,
+                "issue_url": "https://github.com/gavinanelson/implication/issues/264"
+            }
+        })));
     }
 
     #[test]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,6 +104,7 @@
         "group": "Self-Hosting",
         "pages": [
           "self-hosting/local-development",
+          "self-hosting/resource-safe-builds",
           "self-hosting/deploy-docker"
         ]
       },

--- a/docs/self-hosting/resource-safe-builds.mdx
+++ b/docs/self-hosting/resource-safe-builds.mdx
@@ -1,0 +1,110 @@
+---
+title: "Resource-safe Builds"
+description: "Build the Vibe Kanban native app and release binaries without exhausting memory on development machines."
+---
+
+Vibe Kanban release and native desktop builds are memory-heavy Rust builds. Use the repository's resource-safe build path when you build locally, especially on 16 GB laptops or shared development hosts.
+
+<Warning>
+Do not run raw `cargo build --release` or raw `cargo tauri build` on low-memory machines unless you have intentionally opted out of the guardrails. Those commands can start multiple compiler and linker jobs and push the machine into swap.
+</Warning>
+
+## What is protected
+
+The repository applies three layers of protection for local release-style builds:
+
+1. `.cargo/config.toml` sets `jobs = 1` so Cargo serialises compiler work by default.
+2. `Cargo.toml` disables release debug information and split debug information by default.
+3. `scripts/resource-safe-cargo.sh` wraps risky local build commands and prints the effective memory settings before it runs Cargo.
+
+These guardrails target local developer machines. CI or release engineering can override them explicitly when symbols or more parallelism are required.
+
+## Build the native app safely
+
+From the repository root, run:
+
+```bash
+pnpm run tauri:build
+```
+
+That script runs:
+
+```bash
+cd crates/tauri-app && ../../scripts/resource-safe-cargo.sh tauri build
+```
+
+The wrapper detects `cargo tauri build` as a native release build and applies memory-safe defaults.
+
+## Build a Rust release target safely
+
+For a direct release build, call the wrapper instead of calling Cargo directly:
+
+```bash
+./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+Expected output includes the active guardrail settings:
+
+```text
+resource-safe cargo: enabled for release/native build
+  CARGO_BUILD_JOBS=1
+  CARGO_INCREMENTAL=0
+  CARGO_PROFILE_RELEASE_DEBUG=0
+  CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=off
+  RUSTFLAGS=-C debuginfo=0
+```
+
+## Override the defaults intentionally
+
+The wrapper preserves settings that you export before invoking it. Use this only when you know the machine has enough memory for the requested build.
+
+```bash
+CARGO_BUILD_JOBS=4 ./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+To disable the wrapper's release/native guard entirely for one command:
+
+```bash
+VK_CARGO_MEMORY_SAFE=0 ./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+<Warning>
+`VK_CARGO_MEMORY_SAFE=0` disables the wrapper defaults only. The repository-level `.cargo/config.toml` still serialises Cargo unless you also override Cargo's job count.
+</Warning>
+
+## Troubleshoot high memory during builds
+
+If a build still makes the machine unresponsive:
+
+1. Stop duplicate or stale builds before starting another one.
+
+   ```bash
+   pkill -f 'cargo tauri build' || true
+   pkill -f 'cargo build --release' || true
+   pkill -f rustc || true
+   ```
+
+2. Confirm the safe route is being used.
+
+   ```bash
+   pnpm run tauri:build
+   ```
+
+   You should see `resource-safe cargo: enabled for release/native build` before Cargo starts.
+
+3. Check for an intentional override in your shell or service environment.
+
+   ```bash
+   env | grep -E '^(VK_CARGO_MEMORY_SAFE|CARGO_BUILD_JOBS|CARGO_PROFILE_RELEASE_DEBUG|CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO|RUSTFLAGS)='
+   ```
+
+4. Retry with the default wrapper settings after removing any overrides.
+
+   ```bash
+   unset VK_CARGO_MEMORY_SAFE CARGO_BUILD_JOBS CARGO_INCREMENTAL CARGO_PROFILE_RELEASE_DEBUG CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO RUSTFLAGS
+   pnpm run tauri:build
+   ```
+
+## When to bypass the safe path
+
+Bypass the safe path only for a deliberate release-engineering task, such as producing debug-symbol artefacts for crash analysis. In that case, run the build on a machine with enough RAM, document the override in the release notes, and avoid doing it on an active laptop session.

--- a/local-build.sh
+++ b/local-build.sh
@@ -42,6 +42,8 @@ fi
 echo "🔍 Detected platform: $PLATFORM"
 echo "🔧 Using target directory: $CARGO_TARGET_DIR"
 
+RESOURCE_SAFE_CARGO="${RESOURCE_SAFE_CARGO:-./scripts/resource-safe-cargo.sh}"
+
 # Set API base URL for remote features
 export VK_SHARED_API_BASE="https://api.vibekanban.com"
 export VITE_VK_SHARED_API_BASE="https://api.vibekanban.com"
@@ -54,8 +56,8 @@ echo "🔨 Building web app..."
 (cd packages/local-web && npm run build)
 
 echo "🔨 Building Rust binaries..."
-cargo build --release --manifest-path Cargo.toml
-cargo build --release --bin vibe-kanban-mcp --manifest-path Cargo.toml
+"$RESOURCE_SAFE_CARGO" build --release --manifest-path Cargo.toml
+"$RESOURCE_SAFE_CARGO" build --release --bin vibe-kanban-mcp --manifest-path Cargo.toml
 
 echo "📦 Creating distribution package..."
 
@@ -113,7 +115,7 @@ if [[ "$1" == "--desktop" || "$1" == "--all" ]]; then
     fs.writeFileSync('$TAURI_CONF', JSON.stringify(conf, null, 2) + '\n');
   "
 
-  cargo tauri build
+  "$RESOURCE_SAFE_CARGO" tauri build
 
   # Restore tauri.conf.json
   git checkout -- "$TAURI_CONF"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "remote:prepare-db": "cd crates/remote && bash scripts/prepare-db.sh",
     "remote:prepare-db:check": "cd crates/remote && bash scripts/prepare-db.sh --check",
     "tauri:dev": "set -a && [ -f .env ] && . ./.env && set +a && export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export VK_ALLOWED_ORIGINS=\"http://localhost:${FRONTEND_PORT}\" && export DISABLE_WORKTREE_CLEANUP=1 && export RUST_LOG=debug && export VITE_VK_SHARED_API_BASE=${VK_SHARED_API_BASE:-} && cd crates/tauri-app && cargo tauri dev --config '{\"build\":{\"devUrl\":\"http://localhost:'\"${FRONTEND_PORT}\"'\"}}'",
-    "tauri:build": "cd crates/tauri-app && cargo tauri build"
+    "tauri:build": "cd crates/tauri-app && ../../scripts/resource-safe-cargo.sh tauri build"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "backend:lint": "cargo clippy --workspace --all-targets --features qa-mode -- -D warnings && cargo clippy --manifest-path crates/remote/Cargo.toml --all-targets -- -D warnings",
     "backend:format": "cargo fmt --all && cargo fmt --all --manifest-path crates/remote/Cargo.toml",
     "backend:dev": "BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) pnpm run backend:dev:watch",
-    "backend:check": "scripts/run-rust-with-bindgen-env.sh cargo check -p server && scripts/check-remote-self-hosted.sh",
+    "backend:check": "scripts/run-rust-with-bindgen-env.sh cargo check --workspace && scripts/check-remote-self-hosted.sh",
     "backend:dev:watch": "DISABLE_WORKTREE_CLEANUP=1 RUST_LOG=debug scripts/backend-dev.sh",
     "dev:qa": "export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export PREVIEW_PROXY_PORT=$(node scripts/setup-dev-environment.js preview_proxy) && export VK_ALLOWED_ORIGINS=\"http://localhost:${FRONTEND_PORT}\" && export VITE_VK_SHARED_API_BASE=${VK_SHARED_API_BASE:-} && concurrently \"pnpm run backend:dev:watch:qa\" \"pnpm run local-web:dev\"",
     "generate-types": "cargo run --bin generate_types",

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -16,6 +16,7 @@ import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
 import { useIsMobile } from '@/shared/hooks/useIsMobile';
 import { cn } from '@/shared/lib/utils';
 import { useCurrentKanbanRouteState } from '@/shared/hooks/useCurrentKanbanRouteState';
+import { useHostId } from '@/shared/providers/HostIdProvider';
 import {
   useUiPreferencesStore,
   resolveKanbanProjectState,
@@ -185,6 +186,7 @@ export function KanbanContainer() {
   } = useOrgContext();
   const { activeWorkspaces } = useWorkspaceContext();
   const { userId } = useAuth();
+  const effectiveHostId = useHostId();
   const autoReviewTransitionsRef = useRef<Set<string>>(new Set());
   const previousIssueStatusByIdRef = useRef<Map<string, string> | null>(null);
   const [pendingAutoReviewsByIssueId, setPendingAutoReviewsByIssueId] =
@@ -687,13 +689,7 @@ export function KanbanContainer() {
 
   const startAutoReviewForIssue = useCallback(
     async (issueId: string) => {
-      const hostId = routeState.hostId;
-      if (!hostId) {
-        console.warn('Skipping auto-review: no remote host is selected', {
-          issueId,
-        });
-        return;
-      }
+      const hostId = effectiveHostId;
       const workspacesForIssue = getWorkspacesForIssue(issueId).filter(
         (workspace) => !workspace.archived && workspace.local_workspace_id
       );
@@ -789,7 +785,7 @@ export function KanbanContainer() {
         });
       }
     },
-    [getTagObjectsForIssue, getWorkspacesForIssue, routeState.hostId]
+    [effectiveHostId, getTagObjectsForIssue, getWorkspacesForIssue]
   );
 
   useEffect(() => {

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -86,6 +86,7 @@ import {
   isReviewStatusName,
   type PendingAutoReview,
 } from '@/shared/lib/autoReviewStatus';
+import { getAutoReviewLocalWorkspaceId } from '@/shared/lib/autoReviewWorkspace';
 
 const areStringSetsEqual = (left: string[], right: string[]): boolean => {
   if (left.length !== right.length) {
@@ -690,11 +691,10 @@ export function KanbanContainer() {
   const startAutoReviewForIssue = useCallback(
     async (issueId: string) => {
       const hostId = effectiveHostId;
-      const workspacesForIssue = getWorkspacesForIssue(issueId).filter(
-        (workspace) => !workspace.archived && workspace.local_workspace_id
+      const localWorkspaceId = getAutoReviewLocalWorkspaceId(
+        getWorkspacesForIssue(issueId),
+        localWorkspacesById
       );
-      const workspace = workspacesForIssue[0];
-      const localWorkspaceId = workspace?.local_workspace_id;
       if (!localWorkspaceId) {
         console.warn(
           'Skipping auto-review: issue has no linked local workspace',
@@ -785,7 +785,12 @@ export function KanbanContainer() {
         });
       }
     },
-    [effectiveHostId, getTagObjectsForIssue, getWorkspacesForIssue]
+    [
+      effectiveHostId,
+      getTagObjectsForIssue,
+      getWorkspacesForIssue,
+      localWorkspacesById,
+    ]
   );
 
   useEffect(() => {

--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -122,7 +122,7 @@ const areKanbanFiltersEqual = (
   );
 };
 
-const AUTO_REVIEW_SESSION_NAME = 'Auto review — Codex';
+const AUTO_REVIEW_SESSION_NAME = 'Auto review - Codex';
 const AUTO_REVIEW_PROMPT = [
   'Review this workspace as an independent Codex reviewer.',
   'Do not make implementation changes unless they are required to run verification or produce review evidence.',

--- a/packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts
+++ b/packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import { equal } from 'node:assert/strict';
+
+import { getAutoReviewLocalWorkspaceId } from './autoReviewWorkspace';
+
+describe('getAutoReviewLocalWorkspaceId', () => {
+  it('selects the first non-archived linked workspace in the local context', () => {
+    equal(
+      getAutoReviewLocalWorkspaceId(
+        [
+          {
+            archived: false,
+            local_workspace_id: 'remote-workspace',
+          },
+          {
+            archived: false,
+            local_workspace_id: 'local-workspace',
+          },
+        ],
+        new Map([['local-workspace', {}]])
+      ),
+      'local-workspace'
+    );
+  });
+
+  it('does not select archived or remote-only linked workspaces', () => {
+    equal(
+      getAutoReviewLocalWorkspaceId(
+        [
+          {
+            archived: false,
+            local_workspace_id: 'remote-workspace',
+          },
+          {
+            archived: true,
+            local_workspace_id: 'local-workspace',
+          },
+        ],
+        new Map([['local-workspace', {}]])
+      ),
+      null
+    );
+  });
+});

--- a/packages/web-core/src/shared/lib/autoReviewWorkspace.ts
+++ b/packages/web-core/src/shared/lib/autoReviewWorkspace.ts
@@ -1,0 +1,18 @@
+export type AutoReviewLinkedWorkspace = {
+  archived?: boolean | null;
+  local_workspace_id?: string | null;
+};
+
+export const getAutoReviewLocalWorkspaceId = (
+  workspaces: AutoReviewLinkedWorkspace[],
+  localWorkspacesById: ReadonlyMap<string, unknown>
+): string | null => {
+  const workspace = workspaces.find(
+    (workspace) =>
+      !workspace.archived &&
+      !!workspace.local_workspace_id &&
+      localWorkspacesById.has(workspace.local_workspace_id)
+  );
+
+  return workspace?.local_workspace_id ?? null;
+};

--- a/packages/web-core/src/shared/lib/implicationAutopilotPresentation.test.ts
+++ b/packages/web-core/src/shared/lib/implicationAutopilotPresentation.test.ts
@@ -7,19 +7,20 @@ import {
 
 describe('implication autopilot presentation', () => {
   it('formats next action tokens as operator-facing copy', () => {
-    expect(getImplicationAutopilotNextActionDisplay('start_auto_review')).toEqual(
-      {
-        label: 'Start auto-review',
-        description: 'Implementation is complete and ready for a Codex review.',
-      }
-    );
+    expect(
+      getImplicationAutopilotNextActionDisplay('start_auto_review')
+    ).toEqual({
+      label: 'Start auto-review',
+      description: 'Implementation is complete and ready for a Codex review.',
+    });
 
-    expect(getImplicationAutopilotNextActionDisplay('wait_for_review_fix')).toEqual(
-      {
-        label: 'Fix running',
-        description: 'Requested changes are being handled by a Codex fix session.',
-      }
-    );
+    expect(
+      getImplicationAutopilotNextActionDisplay('wait_for_review_fix')
+    ).toEqual({
+      label: 'Fix running',
+      description:
+        'Requested changes are being handled by a Codex fix session.',
+    });
 
     expect(getImplicationAutopilotNextActionDisplay('ready_for_merge')).toEqual(
       {

--- a/packages/web-core/src/shared/lib/implicationAutopilotPresentation.ts
+++ b/packages/web-core/src/shared/lib/implicationAutopilotPresentation.ts
@@ -35,7 +35,8 @@ const NEXT_ACTION_DISPLAY: Record<
   },
   ready_for_merge: {
     label: 'Ready for merge',
-    description: 'Auto-review passed; open the PR and complete the merge handoff.',
+    description:
+      'Auto-review passed; open the PR and complete the merge handoff.',
   },
   merge_wait: {
     label: 'Merge in progress',

--- a/packages/web-core/src/shared/providers/HostIdProvider.tsx
+++ b/packages/web-core/src/shared/providers/HostIdProvider.tsx
@@ -1,45 +1,12 @@
 import {
   createContext,
   useContext,
-  useEffect,
   useLayoutEffect,
   useMemo,
-  useState,
   type ReactNode,
 } from 'react';
 import { useCurrentAppDestination } from '@/shared/hooks/useCurrentAppDestination';
 import { getDestinationHostId } from '@/shared/lib/routes/appNavigation';
-import {
-  listPairedRelayHosts,
-  subscribeRelayPairingChanges,
-} from '@/shared/lib/relayPairingStorage';
-
-type BackendPairedRelayHost = {
-  host_id: string;
-  host_name?: string;
-  paired_at?: string;
-};
-
-async function listBackendPairedRelayHosts(): Promise<
-  BackendPairedRelayHost[]
-> {
-  const response = await fetch('/api/relay-auth/client/hosts', {
-    headers: { Accept: 'application/json' },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to list paired relay hosts: ${response.status}`);
-  }
-
-  const body = (await response.json()) as {
-    success?: boolean;
-    data?: { hosts?: BackendPairedRelayHost[] };
-  };
-
-  return body.success === true && Array.isArray(body.data?.hosts)
-    ? body.data.hosts
-    : [];
-}
 
 // Module-level getter so the API transport can read the hostId outside React
 let _hostId: string | null = null;
@@ -71,54 +38,10 @@ export function HostIdProvider({ children }: { children: ReactNode }) {
     () => getDestinationHostId(destination),
     [destination]
   );
-  const [singlePairedHostId, setSinglePairedHostId] = useState<string | null>(
-    null
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const refreshSinglePairedHost = async () => {
-      try {
-        const [indexedDbHosts, backendHosts] = await Promise.allSettled([
-          listPairedRelayHosts(),
-          listBackendPairedRelayHosts(),
-        ]);
-        if (cancelled) return;
-
-        const hostIds = new Set<string>();
-        if (indexedDbHosts.status === 'fulfilled') {
-          for (const host of indexedDbHosts.value) {
-            hostIds.add(host.host_id);
-          }
-        }
-        if (backendHosts.status === 'fulfilled') {
-          for (const host of backendHosts.value) {
-            hostIds.add(host.host_id);
-          }
-        }
-
-        setSinglePairedHostId(hostIds.size === 1 ? [...hostIds][0] : null);
-      } catch (error) {
-        if (!cancelled) {
-          console.warn('Failed to resolve paired relay hosts', error);
-          setSinglePairedHostId(null);
-        }
-      }
-    };
-
-    void refreshSinglePairedHost();
-    const unsubscribe = subscribeRelayPairingChanges(() => {
-      void refreshSinglePairedHost();
-    });
-
-    return () => {
-      cancelled = true;
-      unsubscribe();
-    };
-  }, []);
-
-  const hostId = routeHostId ?? singlePairedHostId;
+  // Do not globally fall back to the only paired host. Host-aware calls on local
+  // routes must stay local unless the current route or a scoped provider
+  // explicitly supplies a host id.
+  const hostId = routeHostId;
 
   useLayoutEffect(() => {
     _hostId = hostId;

--- a/scripts/resource-safe-cargo.sh
+++ b/scripts/resource-safe-cargo.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Release/native Rust builds can exceed the RAM available on 16GB Linux
+# laptops when Cargo fans out multiple rustc/linker jobs and emits debug info.
+# Keep local release-style builds serialized by default. Operators can override
+# any setting by exporting it before invoking this script, or disable the guard
+# entirely with VK_CARGO_MEMORY_SAFE=0.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "$#" -eq 0 ]]; then
+  echo "usage: $0 <cargo-subcommand> [args...]" >&2
+  exit 64
+fi
+
+is_release_or_native_build() {
+  local arg
+
+  for arg in "$@"; do
+    if [[ "${arg}" == "--release" ]]; then
+      return 0
+    fi
+  done
+
+  # `cargo tauri build` performs a native desktop release build by default and
+  # is the riskiest local path on low-memory laptops.
+  if [[ "${1:-}" == "tauri" && "${2:-}" == "build" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+setting_source() {
+  local name="$1"
+
+  if [[ -n "${!name:-}" ]]; then
+    printf 'user'
+  else
+    printf 'default'
+  fi
+}
+
+if [[ "${VK_CARGO_MEMORY_SAFE:-1}" != "0" ]] && is_release_or_native_build "$@"; then
+  cargo_build_jobs_source="$(setting_source CARGO_BUILD_JOBS)"
+  cargo_incremental_source="$(setting_source CARGO_INCREMENTAL)"
+  release_debug_source="$(setting_source CARGO_PROFILE_RELEASE_DEBUG)"
+  release_split_debuginfo_source="$(setting_source CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO)"
+  rustflags_source="$(setting_source RUSTFLAGS)"
+
+  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
+  export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
+  export CARGO_PROFILE_RELEASE_DEBUG="${CARGO_PROFILE_RELEASE_DEBUG:-0}"
+  export CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO="${CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO:-off}"
+  export RUSTFLAGS="${RUSTFLAGS:--C debuginfo=0}"
+
+  echo "resource-safe cargo: enabled for release/native build" >&2
+  echo "  CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS} (${cargo_build_jobs_source})" >&2
+  echo "  CARGO_INCREMENTAL=${CARGO_INCREMENTAL} (${cargo_incremental_source})" >&2
+  echo "  CARGO_PROFILE_RELEASE_DEBUG=${CARGO_PROFILE_RELEASE_DEBUG} (${release_debug_source})" >&2
+  echo "  CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=${CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO} (${release_split_debuginfo_source})" >&2
+  echo "  RUSTFLAGS=${RUSTFLAGS} (${rustflags_source})" >&2
+  echo "  override: set env vars explicitly, or VK_CARGO_MEMORY_SAFE=0 to disable" >&2
+else
+  echo "resource-safe cargo: no release/native guard applied" >&2
+fi
+
+exec "${SCRIPT_DIR}/run-rust-with-bindgen-env.sh" cargo "$@"

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -270,7 +270,9 @@ export type AutopilotProcessSummary = { id: string, session_id: string, session_
 
 export type ImplicationAutopilotStatus = { workspace_id: string, workspace_name: string | null, implementation_state: string, auto_review_state: AutopilotDecision, latest_review_decision: AutopilotDecision, latest_review_excerpt: string | null, review_fix_state: string, pr_merge_state: string, next_action: AutopilotNextAction, blocker: string | null, implementation_process: AutopilotProcessSummary | null, auto_review_process: AutopilotProcessSummary | null, review_fix_process: AutopilotProcessSummary | null, default_model: string, default_reasoning: string, daemonized: boolean, };
 
-export type StartAutopilotReviewRequest = { rerun: boolean, };
+export type StartAutopilotReviewRequest = { rerun: boolean, github_repo_full_name: string | null, };
+
+export type StartAutopilotReviewFixRequest = { github_repo_full_name: string | null, };
 
 export type TagSearchParams = { search: string | null, };
 


### PR DESCRIPTION
## Summary
- Add a Self-Hosting docs page for resource-safe native/release builds.
- Link the new page from Mintlify navigation.
- Add README and AGENTS guidance so future agents use the safe build wrapper instead of raw release/native Cargo commands.

## Validation
- [x] `python3 -m json.tool docs/docs.json >/dev/null`
- [x] `bash -n scripts/resource-safe-cargo.sh`
- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- [x] `git diff --check`
- [ ] `pnpm exec prettier --check AGENTS.md README.md docs/self-hosting/resource-safe-builds.mdx docs/docs.json` (blocked: root workspace does not expose a `prettier` binary in this checkout)

## Spec + audit trail
- Documents the memory guardrail added for local native/release builds.
- States the safe commands, override contract, and troubleshooting steps.
- Does not run a heavy release/native build as validation.

## Issue update
- Requested directly by Gavin in chat: properly document the Vibe Kanban build RAM guardrails.

## UI evidence
- N/A — docs-only change.