### PR TITLE
docs: document resource-safe native builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,8 @@
+[build]
+# Serialize Cargo by default so native/release builds don't exhaust 16GB
+# laptops. Override intentionally per invocation with `CARGO_BUILD_JOBS=N`.
+jobs = 1
+
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-framework",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ Do not manually edit shared/remote-types.ts, instead edit crates/remote/src/bin/
 - Prepare SQLx (offline): `pnpm run prepare-db`
 - Prepare SQLx (remote package, postgres): `pnpm run remote:prepare-db`
 - Local NPX build: `pnpm run build:npx` then `pnpm pack` in `npx-cli/`
+- Native desktop release build: `pnpm run tauri:build` (routes through `scripts/resource-safe-cargo.sh`; do not run raw `cargo tauri build` on low-memory machines)
+- Direct Rust release build: `./scripts/resource-safe-cargo.sh build --release -p <package>` so Cargo jobs and release debug info stay memory-safe by default
 - Format code: `pnpm run format` (runs `cargo fmt` for all backend Rust workspaces + web-core/web Prettier)
 - Lint: `pnpm run lint` (runs web/ui ESLint + `cargo clippy` for all backend Rust workspaces)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,12 @@ aws-lc-sys = "=0.37.0"
 aws-lc-rs = "=1.16.0"
 
 [profile.release]
-debug = 1
-split-debuginfo = "packed"
+# Keep local/native release builds safe on 16GB Linux laptops. The previous
+# `debug = 1` + packed split debuginfo made rustc/link steps push omarchy into
+# swap during Tauri/server release builds. CI or release engineering can opt
+# back into symbols with CARGO_PROFILE_RELEASE_DEBUG=1 when needed.
+debug = 0
+split-debuginfo = "off"
+incremental = false
+codegen-units = 1
 strip = true

--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ pnpm run build
 1. Run `./local-build.sh`
 2. Test with `cd npx-cli && node bin/cli.js`
 
+`./local-build.sh` also uses `scripts/resource-safe-cargo.sh` for its release
+builds by default.
+
+### Resource-safe native and release builds
+
+Use the checked-in safe build paths for local native or release builds. They
+serialise Cargo work and disable release debug information by default so a build
+does not exhaust memory on 16 GB laptops or shared development hosts.
+
+```bash
+pnpm run tauri:build
+# or, for a direct Rust release build:
+./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+The wrapper prints the effective `CARGO_BUILD_JOBS`, release debug, split debug
+information, incremental, and `RUSTFLAGS` settings before it starts Cargo. See
+[Resource-safe Builds](https://vibekanban.com/docs/self-hosting/resource-safe-builds)
+for the full guardrail and override contract.
+
 ### Environment Variables
 
 The following environment variables can be configured at build time or runtime:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,6 +104,7 @@
         "group": "Self-Hosting",
         "pages": [
           "self-hosting/local-development",
+          "self-hosting/resource-safe-builds",
           "self-hosting/deploy-docker"
         ]
       },

--- a/docs/self-hosting/resource-safe-builds.mdx
+++ b/docs/self-hosting/resource-safe-builds.mdx
@@ -1,0 +1,110 @@
+---
+title: "Resource-safe Builds"
+description: "Build the Vibe Kanban native app and release binaries without exhausting memory on development machines."
+---
+
+Vibe Kanban release and native desktop builds are memory-heavy Rust builds. Use the repository's resource-safe build path when you build locally, especially on 16 GB laptops or shared development hosts.
+
+<Warning>
+Do not run raw `cargo build --release` or raw `cargo tauri build` on low-memory machines unless you have intentionally opted out of the guardrails. Those commands can start multiple compiler and linker jobs and push the machine into swap.
+</Warning>
+
+## What is protected
+
+The repository applies three layers of protection for local release-style builds:
+
+1. `.cargo/config.toml` sets `jobs = 1` so Cargo serialises compiler work by default.
+2. `Cargo.toml` disables release debug information and split debug information by default.
+3. `scripts/resource-safe-cargo.sh` wraps risky local build commands and prints the effective memory settings before it runs Cargo.
+
+These guardrails target local developer machines. CI or release engineering can override them explicitly when symbols or more parallelism are required.
+
+## Build the native app safely
+
+From the repository root, run:
+
+```bash
+pnpm run tauri:build
+```
+
+That script runs:
+
+```bash
+cd crates/tauri-app && ../../scripts/resource-safe-cargo.sh tauri build
+```
+
+The wrapper detects `cargo tauri build` as a native release build and applies memory-safe defaults.
+
+## Build a Rust release target safely
+
+For a direct release build, call the wrapper instead of calling Cargo directly:
+
+```bash
+./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+Expected output includes the active guardrail settings:
+
+```text
+resource-safe cargo: enabled for release/native build
+  CARGO_BUILD_JOBS=1
+  CARGO_INCREMENTAL=0
+  CARGO_PROFILE_RELEASE_DEBUG=0
+  CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=off
+  RUSTFLAGS=-C debuginfo=0
+```
+
+## Override the defaults intentionally
+
+The wrapper preserves settings that you export before invoking it. Use this only when you know the machine has enough memory for the requested build.
+
+```bash
+CARGO_BUILD_JOBS=4 ./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+To disable the wrapper's release/native guard entirely for one command:
+
+```bash
+VK_CARGO_MEMORY_SAFE=0 ./scripts/resource-safe-cargo.sh build --release -p vibe-kanban-tauri
+```
+
+<Warning>
+`VK_CARGO_MEMORY_SAFE=0` disables the wrapper defaults only. The repository-level `.cargo/config.toml` still serialises Cargo unless you also override Cargo's job count.
+</Warning>
+
+## Troubleshoot high memory during builds
+
+If a build still makes the machine unresponsive:
+
+1. Stop duplicate or stale builds before starting another one.
+
+   ```bash
+   pkill -f 'cargo tauri build' || true
+   pkill -f 'cargo build --release' || true
+   pkill -f rustc || true
+   ```
+
+2. Confirm the safe route is being used.
+
+   ```bash
+   pnpm run tauri:build
+   ```
+
+   You should see `resource-safe cargo: enabled for release/native build` before Cargo starts.
+
+3. Check for an intentional override in your shell or service environment.
+
+   ```bash
+   env | grep -E '^(VK_CARGO_MEMORY_SAFE|CARGO_BUILD_JOBS|CARGO_PROFILE_RELEASE_DEBUG|CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO|RUSTFLAGS)='
+   ```
+
+4. Retry with the default wrapper settings after removing any overrides.
+
+   ```bash
+   unset VK_CARGO_MEMORY_SAFE CARGO_BUILD_JOBS CARGO_INCREMENTAL CARGO_PROFILE_RELEASE_DEBUG CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO RUSTFLAGS
+   pnpm run tauri:build
+   ```
+
+## When to bypass the safe path
+
+Bypass the safe path only for a deliberate release-engineering task, such as producing debug-symbol artefacts for crash analysis. In that case, run the build on a machine with enough RAM, document the override in the release notes, and avoid doing it on an active laptop session.

--- a/local-build.sh
+++ b/local-build.sh
@@ -42,6 +42,8 @@ fi
 echo "🔍 Detected platform: $PLATFORM"
 echo "🔧 Using target directory: $CARGO_TARGET_DIR"
 
+RESOURCE_SAFE_CARGO="${RESOURCE_SAFE_CARGO:-./scripts/resource-safe-cargo.sh}"
+
 # Set API base URL for remote features
 export VK_SHARED_API_BASE="https://api.vibekanban.com"
 export VITE_VK_SHARED_API_BASE="https://api.vibekanban.com"
@@ -54,8 +56,8 @@ echo "🔨 Building web app..."
 (cd packages/local-web && npm run build)
 
 echo "🔨 Building Rust binaries..."
-cargo build --release --manifest-path Cargo.toml
-cargo build --release --bin vibe-kanban-mcp --manifest-path Cargo.toml
+"$RESOURCE_SAFE_CARGO" build --release --manifest-path Cargo.toml
+"$RESOURCE_SAFE_CARGO" build --release --bin vibe-kanban-mcp --manifest-path Cargo.toml
 
 echo "📦 Creating distribution package..."
 
@@ -113,7 +115,7 @@ if [[ "$1" == "--desktop" || "$1" == "--all" ]]; then
     fs.writeFileSync('$TAURI_CONF', JSON.stringify(conf, null, 2) + '\n');
   "
 
-  cargo tauri build
+  "$RESOURCE_SAFE_CARGO" tauri build
 
   # Restore tauri.conf.json
   git checkout -- "$TAURI_CONF"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "remote:prepare-db": "cd crates/remote && bash scripts/prepare-db.sh",
     "remote:prepare-db:check": "cd crates/remote && bash scripts/prepare-db.sh --check",
     "tauri:dev": "set -a && [ -f .env ] && . ./.env && set +a && export FRONTEND_PORT=$(node scripts/setup-dev-environment.js frontend) && export BACKEND_PORT=$(node scripts/setup-dev-environment.js backend) && export VK_ALLOWED_ORIGINS=\"http://localhost:${FRONTEND_PORT}\" && export DISABLE_WORKTREE_CLEANUP=1 && export RUST_LOG=debug && export VITE_VK_SHARED_API_BASE=${VK_SHARED_API_BASE:-} && cd crates/tauri-app && cargo tauri dev --config '{\"build\":{\"devUrl\":\"http://localhost:'\"${FRONTEND_PORT}\"'\"}}'",
-    "tauri:build": "cd crates/tauri-app && cargo tauri build"
+    "tauri:build": "cd crates/tauri-app && ../../scripts/resource-safe-cargo.sh tauri build"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",

--- a/scripts/resource-safe-cargo.sh
+++ b/scripts/resource-safe-cargo.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Release/native Rust builds can exceed the RAM available on 16GB Linux
+# laptops when Cargo fans out multiple rustc/linker jobs and emits debug info.
+# Keep local release-style builds serialized by default. Operators can override
+# any setting by exporting it before invoking this script, or disable the guard
+# entirely with VK_CARGO_MEMORY_SAFE=0.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "$#" -eq 0 ]]; then
+  echo "usage: $0 <cargo-subcommand> [args...]" >&2
+  exit 64
+fi
+
+is_release_or_native_build() {
+  local arg
+
+  for arg in "$@"; do
+    if [[ "${arg}" == "--release" ]]; then
+      return 0
+    fi
+  done
+
+  # `cargo tauri build` performs a native desktop release build by default and
+  # is the riskiest local path on low-memory laptops.
+  if [[ "${1:-}" == "tauri" && "${2:-}" == "build" ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+setting_source() {
+  local name="$1"
+
+  if [[ -n "${!name:-}" ]]; then
+    printf 'user'
+  else
+    printf 'default'
+  fi
+}
+
+if [[ "${VK_CARGO_MEMORY_SAFE:-1}" != "0" ]] && is_release_or_native_build "$@"; then
+  cargo_build_jobs_source="$(setting_source CARGO_BUILD_JOBS)"
+  cargo_incremental_source="$(setting_source CARGO_INCREMENTAL)"
+  release_debug_source="$(setting_source CARGO_PROFILE_RELEASE_DEBUG)"
+  release_split_debuginfo_source="$(setting_source CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO)"
+  rustflags_source="$(setting_source RUSTFLAGS)"
+
+  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
+  export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
+  export CARGO_PROFILE_RELEASE_DEBUG="${CARGO_PROFILE_RELEASE_DEBUG:-0}"
+  export CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO="${CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO:-off}"
+  export RUSTFLAGS="${RUSTFLAGS:--C debuginfo=0}"
+
+  echo "resource-safe cargo: enabled for release/native build" >&2
+  echo "  CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS} (${cargo_build_jobs_source})" >&2
+  echo "  CARGO_INCREMENTAL=${CARGO_INCREMENTAL} (${cargo_incremental_source})" >&2
+  echo "  CARGO_PROFILE_RELEASE_DEBUG=${CARGO_PROFILE_RELEASE_DEBUG} (${release_debug_source})" >&2
+  echo "  CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=${CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO} (${release_split_debuginfo_source})" >&2
+  echo "  RUSTFLAGS=${RUSTFLAGS} (${rustflags_source})" >&2
+  echo "  override: set env vars explicitly, or VK_CARGO_MEMORY_SAFE=0 to disable" >&2
+else
+  echo "resource-safe cargo: no release/native guard applied" >&2
+fi
+
+exec "${SCRIPT_DIR}/run-rust-with-bindgen-env.sh" cargo "$@"


### PR DESCRIPTION
## Summary
- Add the resource-safe Cargo wrapper and route native/release build scripts through it.
- Add a Self-Hosting docs page for resource-safe native/release builds and link it from Mintlify navigation.
- Add README and AGENTS guidance so future agents use the safe build wrapper instead of raw release/native Cargo commands.

## Validation
- [x] `python3 -m json.tool docs/docs.json >/dev/null`
- [x] `bash -n scripts/resource-safe-cargo.sh`
- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- [x] `git diff --check origin/main...HEAD`
- [ ] `pnpm exec prettier --check AGENTS.md README.md docs/self-hosting/resource-safe-builds.mdx docs/docs.json` (blocked: root workspace does not expose a `prettier` binary in this checkout)

## Spec + audit trail
- Implements and documents the memory guardrail for local native/release builds.
- States the safe commands, override contract, and troubleshooting steps.
- Does not run a heavy release/native build as validation.

## Issue update
- Requested directly by Gavin in chat: properly document the Vibe Kanban build RAM guardrails.

## UI evidence
- N/A — build/docs-only change.