### PR TITLE
fix: retry auto-review when workspace sync lags

### DIFF
--- a/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
+++ b/packages/web-core/src/features/kanban/ui/KanbanContainer.tsx
@@ -87,7 +87,7 @@ import {
   type PendingAutoReview,
 } from '@/shared/lib/autoReviewStatus';
 import { getAutoReviewTransitionIssueIds } from '@/shared/lib/autoReviewTransitions';
-import { getAutoReviewLocalWorkspaceId } from '@/shared/lib/autoReviewWorkspace';
+import { getAutoReviewWorkspaceResolution } from '@/shared/lib/autoReviewWorkspace';
 
 const areStringSetsEqual = (left: string[], right: string[]): boolean => {
   if (left.length !== right.length) {
@@ -698,11 +698,16 @@ export function KanbanContainer() {
       }
 
       const hostId = effectiveHostId;
-      const localWorkspaceId = getAutoReviewLocalWorkspaceId(
+      const workspaceResolution = getAutoReviewWorkspaceResolution(
         getWorkspacesForIssue(issueId),
         localWorkspacesById
       );
-      if (!localWorkspaceId) {
+      if (workspaceResolution.state === 'pending-local-workspace') {
+        pendingAutoReviewIssueIdsRef.current.add(issueId);
+        return;
+      }
+
+      if (workspaceResolution.state === 'no-linked-workspace') {
         console.warn(
           'Skipping auto-review: issue has no linked local workspace',
           {
@@ -712,6 +717,7 @@ export function KanbanContainer() {
         return;
       }
 
+      const localWorkspaceId = workspaceResolution.localWorkspaceId;
       const transitionKey = `${issueId}:${localWorkspaceId}`;
       if (autoReviewTransitionsRef.current.has(transitionKey)) {
         return;

--- a/packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts
+++ b/packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from 'node:test';
-import { equal } from 'node:assert/strict';
+import { deepEqual, equal } from 'node:assert/strict';
 
-import { getAutoReviewLocalWorkspaceId } from './autoReviewWorkspace';
+import {
+  getAutoReviewLocalWorkspaceId,
+  getAutoReviewWorkspaceResolution,
+} from './autoReviewWorkspace.ts';
 
 describe('getAutoReviewLocalWorkspaceId', () => {
   it('selects the first non-archived linked workspace in the local context', () => {
@@ -39,6 +42,46 @@ describe('getAutoReviewLocalWorkspaceId', () => {
         new Map([['local-workspace', {}]])
       ),
       null
+    );
+  });
+});
+
+describe('getAutoReviewWorkspaceResolution', () => {
+  it('returns pending-local-workspace when a linked local workspace is not loaded yet', () => {
+    deepEqual(
+      getAutoReviewWorkspaceResolution(
+        [
+          {
+            archived: false,
+            local_workspace_id: 'local-workspace',
+          },
+        ],
+        new Map()
+      ),
+      {
+        state: 'pending-local-workspace',
+      }
+    );
+  });
+
+  it('returns no-linked-workspace when no non-archived workspace has a local id', () => {
+    deepEqual(
+      getAutoReviewWorkspaceResolution(
+        [
+          {
+            archived: false,
+            local_workspace_id: null,
+          },
+          {
+            archived: true,
+            local_workspace_id: 'archived-local-workspace',
+          },
+        ],
+        new Map([['archived-local-workspace', {}]])
+      ),
+      {
+        state: 'no-linked-workspace',
+      }
     );
   });
 });

--- a/packages/web-core/src/shared/lib/autoReviewWorkspace.ts
+++ b/packages/web-core/src/shared/lib/autoReviewWorkspace.ts
@@ -3,16 +3,55 @@ export type AutoReviewLinkedWorkspace = {
   local_workspace_id?: string | null;
 };
 
-export const getAutoReviewLocalWorkspaceId = (
+export type AutoReviewWorkspaceResolution =
+  | {
+      state: 'ready';
+      localWorkspaceId: string;
+    }
+  | {
+      state: 'pending-local-workspace';
+    }
+  | {
+      state: 'no-linked-workspace';
+    };
+
+export const getAutoReviewWorkspaceResolution = (
   workspaces: AutoReviewLinkedWorkspace[],
   localWorkspacesById: ReadonlyMap<string, unknown>
-): string | null => {
-  const workspace = workspaces.find(
+): AutoReviewWorkspaceResolution => {
+  const linkedWorkspace = workspaces.find(
     (workspace) =>
       !workspace.archived &&
       !!workspace.local_workspace_id &&
       localWorkspacesById.has(workspace.local_workspace_id)
   );
 
-  return workspace?.local_workspace_id ?? null;
+  if (linkedWorkspace?.local_workspace_id) {
+    return {
+      state: 'ready',
+      localWorkspaceId: linkedWorkspace.local_workspace_id,
+    };
+  }
+
+  const hasPendingLocalWorkspace = workspaces.some(
+    (workspace) => !workspace.archived && !!workspace.local_workspace_id
+  );
+
+  if (hasPendingLocalWorkspace) {
+    return { state: 'pending-local-workspace' };
+  }
+
+  return { state: 'no-linked-workspace' };
+};
+
+export const getAutoReviewLocalWorkspaceId = (
+  workspaces: AutoReviewLinkedWorkspace[],
+  localWorkspacesById: ReadonlyMap<string, unknown>
+): string | null => {
+  const resolution = getAutoReviewWorkspaceResolution(
+    workspaces,
+    localWorkspacesById
+  );
+
+  return resolution.state === 'ready' ? resolution.localWorkspaceId : null;
 };


### PR DESCRIPTION
## Summary
- keep Kanban auto-review requests pending when the remote card has a linked local workspace id but the local workspace stream has not caught up yet
- retry once local workspace data appears instead of silently dropping the review trigger
- add focused helper coverage for pending workspace resolution

## Validation
- node --experimental-strip-types --test packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts packages/web-core/src/shared/lib/autoReviewTransitions.test.ts
- pnpm --filter @vibe/web-core run check

## UI evidence
- N/A: focused trigger/retry logic; native rebuild not run locally to avoid RAM-heavy Tauri builds.