### PR TITLE
fix: preserve cargo target rustflags in safe builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ pnpm run tauri:build
 ```
 
 The wrapper prints the effective `CARGO_BUILD_JOBS`, release debug, split debug
-information, incremental, and `RUSTFLAGS` settings before it starts Cargo. See
+information, and incremental settings before it starts Cargo. It preserves
+Cargo's target-specific rustflags unless you intentionally export `RUSTFLAGS`.
+See
 [Resource-safe Builds](https://vibekanban.com/docs/self-hosting/resource-safe-builds)
 for the full guardrail and override contract.
 

--- a/docs/self-hosting/resource-safe-builds.mdx
+++ b/docs/self-hosting/resource-safe-builds.mdx
@@ -51,7 +51,7 @@ resource-safe cargo: enabled for release/native build
   CARGO_INCREMENTAL=0
   CARGO_PROFILE_RELEASE_DEBUG=0
   CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=off
-  RUSTFLAGS=-C debuginfo=0
+  RUSTFLAGS=<unset> (preserving Cargo target-specific rustflags)
 ```
 
 ## Override the defaults intentionally

--- a/scripts/resource-safe-cargo.sh
+++ b/scripts/resource-safe-cargo.sh
@@ -48,20 +48,21 @@ if [[ "${VK_CARGO_MEMORY_SAFE:-1}" != "0" ]] && is_release_or_native_build "$@";
   cargo_incremental_source="$(setting_source CARGO_INCREMENTAL)"
   release_debug_source="$(setting_source CARGO_PROFILE_RELEASE_DEBUG)"
   release_split_debuginfo_source="$(setting_source CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO)"
-  rustflags_source="$(setting_source RUSTFLAGS)"
-
   export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
   export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-0}"
   export CARGO_PROFILE_RELEASE_DEBUG="${CARGO_PROFILE_RELEASE_DEBUG:-0}"
   export CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO="${CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO:-off}"
-  export RUSTFLAGS="${RUSTFLAGS:--C debuginfo=0}"
 
   echo "resource-safe cargo: enabled for release/native build" >&2
   echo "  CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS} (${cargo_build_jobs_source})" >&2
   echo "  CARGO_INCREMENTAL=${CARGO_INCREMENTAL} (${cargo_incremental_source})" >&2
   echo "  CARGO_PROFILE_RELEASE_DEBUG=${CARGO_PROFILE_RELEASE_DEBUG} (${release_debug_source})" >&2
   echo "  CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=${CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO} (${release_split_debuginfo_source})" >&2
-  echo "  RUSTFLAGS=${RUSTFLAGS} (${rustflags_source})" >&2
+  if [[ -n "${RUSTFLAGS:-}" ]]; then
+    echo "  RUSTFLAGS=${RUSTFLAGS} (user; preserved)" >&2
+  else
+    echo "  RUSTFLAGS=<unset> (preserving Cargo target-specific rustflags)" >&2
+  fi
   echo "  override: set env vars explicitly, or VK_CARGO_MEMORY_SAFE=0 to disable" >&2
 else
   echo "resource-safe cargo: no release/native guard applied" >&2


### PR DESCRIPTION
## Summary
- preserve Cargo target-specific rustflags when the resource-safe wrapper runs without an explicit `RUSTFLAGS`
- keep release/native memory guardrails through Cargo profile env vars and serialized jobs
- update docs/README output so operators see that target rustflags are preserved instead of overwritten

## Validation
- [x] `bash -n scripts/resource-safe-cargo.sh`
- [x] `./scripts/resource-safe-cargo.sh build --release --help >/tmp/vk-wrapper-help.out`
- [x] `node --test packages/web-core/src/shared/lib/autoReviewTransitions.test.ts packages/web-core/src/shared/lib/autoReviewWorkspace.test.ts packages/web-core/src/shared/lib/implicationAutopilotPresentation.test.ts`
- [x] `pnpm --filter @vibe/web-core run check`
- [x] `pnpm --filter @vibe/ui run check`
- [x] `pnpm --filter @vibe/local-web run check`
- [x] `python3 -m py_compile scripts/implication-kanban-autopilot.py`
- [x] `python3 scripts/implication-kanban-autopilot.py --self-test`
- [x] `python3 -m json.tool docs/docs.json >/dev/null`

## Spec + audit trail
- Codex review on PR #9 found that defaulting `RUSTFLAGS=-C debuginfo=0` can suppress target-specific rustflags from `.cargo/config.toml` for macOS/Windows native builds.
- This PR removes the default `RUSTFLAGS` override while keeping `CARGO_PROFILE_RELEASE_DEBUG=0` and `CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO=off` as the debug-info guardrail.

## Issue update
- Follow-up to PR #9 after Codex review finding.

## UI evidence
- N/A; build guardrail/docs fix only.
