### PR TITLE
feat: let app advance autopilot merge reconciliation

### DIFF
--- a/crates/git-host/src/azure/mod.rs
+++ b/crates/git-host/src/azure/mod.rs
@@ -256,6 +256,10 @@ impl GitHostProvider for AzureDevOpsProvider {
         Err(GitHostError::UnsupportedProvider)
     }
 
+    async fn merge_pr(&self, _pr_url: &str) -> Result<PullRequestDetail, GitHostError> {
+        Err(GitHostError::UnsupportedProvider)
+    }
+
     fn provider_kind(&self) -> ProviderKind {
         ProviderKind::AzureDevOps
     }

--- a/crates/git-host/src/github/cli.rs
+++ b/crates/git-host/src/github/cli.rs
@@ -297,6 +297,12 @@ impl GhCli {
         Self::parse_pr_view(&raw)
     }
 
+    /// Merge a pull request through GitHub's normal branch protection checks.
+    pub fn merge_pr(&self, pr_url: &str) -> Result<PullRequestDetail, GhCliError> {
+        self.run(["pr", "merge", pr_url, "--squash", "--delete-branch"], None)?;
+        self.view_pr(pr_url)
+    }
+
     /// List pull requests for a branch (includes closed/merged).
     pub fn list_prs_for_branch(
         &self,

--- a/crates/git-host/src/github/mod.rs
+++ b/crates/git-host/src/github/mod.rs
@@ -254,6 +254,20 @@ impl GitHostProvider for GitHubProvider {
         .await
     }
 
+    async fn merge_pr(&self, pr_url: &str) -> Result<PullRequestDetail, GitHostError> {
+        let cli = self.gh_cli.clone();
+        let url = pr_url.to_string();
+
+        let pr = task::spawn_blocking(move || cli.merge_pr(&url))
+            .await
+            .map_err(|err| {
+                GitHostError::PullRequest(format!(
+                    "Failed to execute GitHub CLI for merging PR: {err}"
+                ))
+            })?;
+        pr.map_err(GitHostError::from)
+    }
+
     async fn list_prs_for_branch(
         &self,
         repo_path: &Path,

--- a/crates/git-host/src/lib.rs
+++ b/crates/git-host/src/lib.rs
@@ -28,6 +28,8 @@ pub trait GitHostProvider: Send + Sync {
 
     async fn get_pr_status(&self, pr_url: &str) -> Result<PullRequestDetail, GitHostError>;
 
+    async fn merge_pr(&self, pr_url: &str) -> Result<PullRequestDetail, GitHostError>;
+
     async fn list_prs_for_branch(
         &self,
         repo_path: &Path,

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -1576,21 +1576,35 @@ async fn infer_pr_merge_state(
     }
 
     let merges = Merge::find_by_workspace_id(&deployment.db().pool, workspace.id).await?;
-    let has_open_pr = merges.iter().any(
-        |merge| matches!(merge, Merge::Pr(pr) if matches!(pr.pr_info.status, MergeStatus::Open)),
-    );
-    let has_merged = merges.iter().any(|merge| match merge {
-        Merge::Direct(_) => true,
-        Merge::Pr(pr) => matches!(pr.pr_info.status, MergeStatus::Merged),
-    });
+    let pr_statuses = merges
+        .iter()
+        .filter_map(|merge| match merge {
+            Merge::Pr(pr) => Some(pr.pr_info.status.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
 
-    if has_open_pr {
+    if pr_statuses
+        .iter()
+        .any(|status| matches!(status, MergeStatus::Open))
+    {
         if workspace_has_dirty_or_conflicting_changes(deployment, workspace).await? {
             return Ok("blocked_by_dirty_worktree".to_string());
         }
         return Ok("pr_open_pending_merge".to_string());
     }
-    if has_merged {
+
+    if let Some(state) = merge_state_from_pr_completion(&pr_statuses) {
+        if state == "merged_pending_done"
+            && workspace.pinned
+            && linked_issue_is_done(deployment, workspace).await?
+        {
+            return Ok("done_or_archived".to_string());
+        }
+        return Ok(state.to_string());
+    }
+
+    if merges.iter().any(|merge| matches!(merge, Merge::Direct(_))) {
         if workspace.pinned && linked_issue_is_done(deployment, workspace).await? {
             return Ok("done_or_archived".to_string());
         }
@@ -1598,6 +1612,16 @@ async fn infer_pr_merge_state(
     }
 
     Ok("no_pr_merge_found".to_string())
+}
+
+fn merge_state_from_pr_completion(statuses: &[MergeStatus]) -> Option<&'static str> {
+    if statuses.is_empty() {
+        return None;
+    }
+    if linked_pr_merge_completion_blocker(statuses).is_none() {
+        return Some("merged_pending_done");
+    }
+    Some("blocked_by_pr_requirements")
 }
 
 async fn linked_issue_is_done(
@@ -2687,6 +2711,23 @@ mod tests {
                     .to_string()
             )
         );
+    }
+
+    #[test]
+    fn merge_state_requires_all_linked_pull_requests_merged_before_done() {
+        assert_eq!(
+            merge_state_from_pr_completion(&[MergeStatus::Merged, MergeStatus::Merged]),
+            Some("merged_pending_done")
+        );
+        assert_eq!(
+            merge_state_from_pr_completion(&[MergeStatus::Merged, MergeStatus::Closed]),
+            Some("blocked_by_pr_requirements")
+        );
+        assert_eq!(
+            merge_state_from_pr_completion(&[MergeStatus::Merged, MergeStatus::Unknown]),
+            Some("blocked_by_pr_requirements")
+        );
+        assert_eq!(merge_state_from_pr_completion(&[]), None);
     }
 
     #[test]

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -326,7 +326,10 @@ async fn advance_workspace(
     ensure_implication_autopilot_allowed(&deployment, &workspace).await?;
 
     let (action_taken, merge_blocker) = advance_workspace_once(&deployment, &workspace).await?;
-    let mut status = build_status(&deployment, &workspace).await?;
+    let status_workspace = Workspace::find_by_id(&deployment.db().pool, workspace.id)
+        .await?
+        .unwrap_or(workspace);
+    let mut status = build_status(&deployment, &status_workspace).await?;
     if let Some(blocker) = merge_blocker {
         status.blocker = Some(blocker.clone());
         status.next_action = AutopilotNextAction::InvestigateFailure;

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -650,7 +650,7 @@ async fn advance_merge_done_once(
             Ok((AutopilotAdvanceAction::Blocked, Some(blocker)))
         }
         AutopilotMergePlan::AttemptPrMerge => {
-            match merge_single_open_pull_request(deployment, workspace).await {
+            match merge_open_pull_requests(deployment, workspace).await {
                 Ok(()) => {
                     reconcile_workspace_done(deployment, workspace, issue).await?;
                     Ok((AutopilotAdvanceAction::Noop, None))
@@ -683,74 +683,203 @@ fn merge_plan_from_state(pr_merge_state: &str) -> AutopilotMergePlan {
     }
 }
 
-async fn merge_single_open_pull_request(
+async fn merge_open_pull_requests(
     deployment: &DeploymentImpl,
     workspace: &Workspace,
 ) -> Result<(), String> {
     let merges = Merge::find_by_workspace_id(&deployment.db().pool, workspace.id)
         .await
         .map_err(|err| format!("Failed to inspect linked pull requests: {err}"))?;
-    let open_prs = merges
+    let linked_prs = merges
         .iter()
         .filter_map(|merge| match merge {
-            Merge::Pr(pr) if matches!(pr.pr_info.status, MergeStatus::Open) => Some(pr),
+            Merge::Pr(pr) => Some(pr.clone()),
             _ => None,
         })
         .collect::<Vec<_>>();
 
-    let [open_pr] = open_prs.as_slice() else {
-        return Err(format!(
-            "Expected exactly one open pull request to merge, found {}.",
-            open_prs.len()
-        ));
-    };
+    if linked_prs.is_empty() {
+        return Err(linked_pr_merge_completion_blocker(&[]).unwrap_or_else(|| {
+            "No linked pull requests were found for this workspace; create or link a PR and rerun app advance."
+                .to_string()
+        }));
+    }
 
-    let git_host = GitHostService::from_url(&open_pr.pr_info.url)
-        .map_err(|err| format!("Cannot identify pull request provider: {err}"))?;
-    let current_pr_info = git_host
-        .get_pr_status(&open_pr.pr_info.url)
-        .await
-        .map_err(|err| format!("Failed to refresh PR merge status from GitHub: {err}"))?;
-    if !matches!(
-        current_pr_info.status,
-        MergeStatus::Open | MergeStatus::Merged
-    ) {
-        persist_pr_status(deployment, workspace, open_pr, current_pr_info).await?;
-        return Err(
-            "Linked pull request is no longer open or mergeable; refreshed PR status and blocked auto-merge."
+    let mut final_statuses = Vec::with_capacity(linked_prs.len());
+    let mut blockers = Vec::new();
+    for linked_pr in &linked_prs {
+        if matches!(linked_pr.pr_info.status, MergeStatus::Merged) {
+            final_statuses.push(MergeStatus::Merged);
+            continue;
+        }
+
+        let git_host = match GitHostService::from_url(&linked_pr.pr_info.url) {
+            Ok(git_host) => git_host,
+            Err(err) => {
+                blockers.push(format!(
+                    "Cannot identify pull request provider for PR #{} ({}): {err}",
+                    linked_pr.pr_info.number, linked_pr.pr_info.url
+                ));
+                final_statuses.push(linked_pr.pr_info.status.clone());
+                continue;
+            }
+        };
+        let current_pr_info = match git_host.get_pr_status(&linked_pr.pr_info.url).await {
+            Ok(pr_info) => pr_info,
+            Err(err) => {
+                blockers.push(format!(
+                    "Failed to refresh PR #{} ({}) merge status from GitHub: {err}",
+                    linked_pr.pr_info.number, linked_pr.pr_info.url
+                ));
+                final_statuses.push(linked_pr.pr_info.status.clone());
+                continue;
+            }
+        };
+        if !matches!(
+            current_pr_info.status,
+            MergeStatus::Open | MergeStatus::Merged
+        ) {
+            let status = current_pr_info.status.clone();
+            if let Err(err) =
+                persist_pr_status(deployment, workspace, linked_pr, current_pr_info).await
+            {
+                blockers.push(format!(
+                    "PR #{} ({}) refreshed as {}, but status persistence failed: {err}",
+                    linked_pr.pr_info.number,
+                    linked_pr.pr_info.url,
+                    merge_status_label(&status)
+                ));
+            }
+            final_statuses.push(status.clone());
+            blockers.push(format!(
+                "Cannot complete autopilot merge: PR #{} ({}) is {} after refresh.",
+                linked_pr.pr_info.number,
+                linked_pr.pr_info.url,
+                merge_status_label(&status)
+            ));
+            continue;
+        }
+
+        let pr_info = if matches!(current_pr_info.status, MergeStatus::Merged) {
+            current_pr_info
+        } else {
+            let pr_info = match git_host.merge_pr(&linked_pr.pr_info.url).await {
+                Ok(pr_info) => pr_info,
+                Err(err) => {
+                    let persist_result =
+                        persist_pr_status(deployment, workspace, linked_pr, current_pr_info).await;
+                    let persist_note = persist_result
+                        .err()
+                        .map(|persist_err| {
+                            format!(" Refreshed PR status persistence also failed: {persist_err}.")
+                        })
+                        .unwrap_or_default();
+                    blockers.push(format!(
+                        "PR #{} ({}) merge is blocked by GitHub requirements: {err}.{persist_note}",
+                        linked_pr.pr_info.number, linked_pr.pr_info.url
+                    ));
+                    final_statuses.push(MergeStatus::Open);
+                    continue;
+                }
+            };
+
+            if !matches!(pr_info.status, MergeStatus::Merged) {
+                let status = pr_info.status.clone();
+                if let Err(err) = persist_pr_status(deployment, workspace, linked_pr, pr_info).await
+                {
+                    blockers.push(format!(
+                        "PR #{} ({}) status persistence failed after merge attempt: {err}",
+                        linked_pr.pr_info.number, linked_pr.pr_info.url
+                    ));
+                }
+                final_statuses.push(status.clone());
+                blockers.push(format!(
+                    "GitHub accepted the merge command for PR #{} ({}), but it is {} instead of merged.",
+                    linked_pr.pr_info.number,
+                    linked_pr.pr_info.url,
+                    merge_status_label(&status)
+                ));
+                continue;
+            }
+            pr_info
+        };
+
+        if let Err(err) = persist_pr_status(deployment, workspace, linked_pr, pr_info).await {
+            blockers.push(format!(
+                "PR #{} ({}) merged, but local/remote PR status update failed: {err}",
+                linked_pr.pr_info.number, linked_pr.pr_info.url
+            ));
+        }
+        final_statuses.push(MergeStatus::Merged);
+    }
+
+    if blockers.is_empty() {
+        linked_pr_merge_completion_blocker(&final_statuses).map_or(Ok(()), Err)
+    } else {
+        Err(blockers.join(" "))
+    }
+}
+
+fn linked_pr_merge_completion_blocker(statuses: &[MergeStatus]) -> Option<String> {
+    if statuses.is_empty() {
+        return Some(
+            "No linked pull requests were found for this workspace; create or link a PR and rerun app advance."
                 .to_string(),
         );
     }
 
-    let pr_info = if matches!(current_pr_info.status, MergeStatus::Merged) {
-        current_pr_info
-    } else {
-        let pr_info = git_host
-            .merge_pr(&open_pr.pr_info.url)
-            .await
-            .map_err(|err| format!("PR merge is blocked by GitHub requirements: {err}"))?;
+    let open_count = statuses
+        .iter()
+        .filter(|status| matches!(status, MergeStatus::Open))
+        .count();
+    if open_count > 0 {
+        return Some(format!(
+            "Not all linked pull requests are merged yet: {open_count} open PR{} remain{} after merge attempts.",
+            if open_count == 1 { "" } else { "s" },
+            if open_count == 1 { "s" } else { "" }
+        ));
+    }
 
-        if !matches!(pr_info.status, MergeStatus::Merged) {
-            persist_pr_status(deployment, workspace, open_pr, pr_info).await?;
-            return Err(
-                "GitHub accepted the merge command but the pull request is not merged yet."
-                    .to_string(),
-            );
-        }
-        pr_info
-    };
+    let closed_count = statuses
+        .iter()
+        .filter(|status| matches!(status, MergeStatus::Closed))
+        .count();
+    if closed_count > 0 {
+        return Some(format!(
+            "Cannot complete autopilot merge: {closed_count} linked PR{} {} closed.",
+            if closed_count == 1 { "" } else { "s" },
+            if closed_count == 1 { "is" } else { "are" }
+        ));
+    }
 
-    persist_pr_status(deployment, workspace, open_pr, pr_info)
-        .await
-        .map_err(|err| format!("PR merged but local/remote PR status update failed: {err}"))?;
+    let unknown_count = statuses
+        .iter()
+        .filter(|status| matches!(status, MergeStatus::Unknown))
+        .count();
+    if unknown_count > 0 {
+        return Some(format!(
+            "Cannot complete autopilot merge: {unknown_count} linked PR{} ha{} unknown status.",
+            if unknown_count == 1 { "" } else { "s" },
+            if unknown_count == 1 { "s" } else { "ve" }
+        ));
+    }
 
-    Ok(())
+    None
+}
+
+fn merge_status_label(status: &MergeStatus) -> &'static str {
+    match status {
+        MergeStatus::Open => "open",
+        MergeStatus::Merged => "merged",
+        MergeStatus::Closed => "closed",
+        MergeStatus::Unknown => "unknown",
+    }
 }
 
 async fn persist_pr_status(
     deployment: &DeploymentImpl,
     workspace: &Workspace,
-    open_pr: &PrMerge,
+    linked_pr: &PrMerge,
     pr_detail: PullRequestDetail,
 ) -> Result<(), String> {
     let status = pr_detail.status.clone();
@@ -775,7 +904,7 @@ async fn persist_pr_status(
             status: pull_request_status_from_merge_status(&status),
             merged_at,
             merge_commit_sha,
-            target_branch_name: open_pr.target_branch_name.clone(),
+            target_branch_name: linked_pr.target_branch_name.clone(),
             local_workspace_id: workspace.id,
         };
         tokio::spawn(async move {
@@ -2509,6 +2638,52 @@ mod tests {
         let plan = merge_plan_from_state("merged_pending_done");
 
         assert_eq!(plan, AutopilotMergePlan::ReconcileDone);
+    }
+
+    #[test]
+    fn linked_pr_completion_allows_multiple_merged_pull_requests() {
+        assert_eq!(
+            linked_pr_merge_completion_blocker(&[MergeStatus::Merged, MergeStatus::Merged]),
+            None
+        );
+    }
+
+    #[test]
+    fn linked_pr_completion_blocks_when_any_pull_request_remains_open() {
+        assert_eq!(
+            linked_pr_merge_completion_blocker(&[
+                MergeStatus::Merged,
+                MergeStatus::Open,
+                MergeStatus::Merged
+            ]),
+            Some(
+                "Not all linked pull requests are merged yet: 1 open PR remains after merge attempts."
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn linked_pr_completion_blocks_closed_or_unknown_pull_requests() {
+        assert_eq!(
+            linked_pr_merge_completion_blocker(&[MergeStatus::Merged, MergeStatus::Closed]),
+            Some("Cannot complete autopilot merge: 1 linked PR is closed.".to_string())
+        );
+        assert_eq!(
+            linked_pr_merge_completion_blocker(&[MergeStatus::Unknown]),
+            Some("Cannot complete autopilot merge: 1 linked PR has unknown status.".to_string())
+        );
+    }
+
+    #[test]
+    fn linked_pr_completion_reports_missing_prs_as_recoverable() {
+        assert_eq!(
+            linked_pr_merge_completion_blocker(&[]),
+            Some(
+                "No linked pull requests were found for this workspace; create or link a PR and rerun app advance."
+                    .to_string()
+            )
+        );
     }
 
     #[test]

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use api_types::{Issue, UpdateIssueRequest};
+use api_types::{Issue, PullRequestStatus, UpdateIssueRequest, UpsertPullRequestRequest};
 use axum::{
     Extension, Json, Router,
     extract::State,
@@ -14,6 +14,8 @@ use axum::{
 use chrono::{DateTime, Utc};
 use db::models::{
     execution_process::{ExecutionProcessRunReason, ExecutionProcessStatus},
+    merge::{Merge, MergeStatus, PrMerge},
+    pull_request::PullRequest,
     session::{CreateSession, Session},
     workspace::{Workspace, WorkspaceError},
     workspace_repo::WorkspaceRepo,
@@ -29,9 +31,10 @@ use executors::{
     model_selector::PermissionPolicy,
     profile::ExecutorConfig,
 };
+use git_host::{GitHostProvider, GitHostService, PullRequestDetail};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use services::services::{container::ContainerService, remote_client::RemoteClient};
+use services::services::{container::ContainerService, remote_client::RemoteClient, remote_sync};
 use sqlx::FromRow;
 use ts_rs::TS;
 use utils::{log_msg::LogMsg, response::ApiResponse};
@@ -156,6 +159,13 @@ pub enum AutopilotAdvanceAction {
     StartedReviewFix,
     MergeHandoff,
     Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AutopilotMergePlan {
+    AttemptPrMerge,
+    ReconcileDone,
+    Blocked(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, TS, PartialEq, Eq)]
@@ -315,8 +325,18 @@ async fn advance_workspace(
 ) -> Result<Json<ApiResponse<ImplicationAutopilotAdvanceResponse>>, ApiError> {
     ensure_implication_autopilot_allowed(&deployment, &workspace).await?;
 
-    let action_taken = advance_workspace_once(&deployment, &workspace).await?;
-    let status = build_status(&deployment, &workspace).await?;
+    let (action_taken, merge_blocker) = advance_workspace_once(&deployment, &workspace).await?;
+    let mut status = build_status(&deployment, &workspace).await?;
+    if let Some(blocker) = merge_blocker {
+        status.blocker = Some(blocker.clone());
+        status.next_action = AutopilotNextAction::InvestigateFailure;
+        status.workflow_state = AutopilotWorkflowState::Blocked;
+        status.workflow_state_reason = blocker;
+        status.token_safety_state = AutopilotTokenSafetyState::Blocked;
+        status.token_safety_note =
+            "Merge/done reconciliation is blocked before another Codex session can start."
+                .to_string();
+    }
     Ok(Json(ApiResponse::success(
         ImplicationAutopilotAdvanceResponse {
             action_taken,
@@ -374,7 +394,8 @@ async fn start_auto_review_for_workspace(
         .find(|row| is_review_fix_session(row.session_name.as_deref()));
     let (latest_review_decision, _, latest_review_process) =
         decide_from_review_attempts(deployment, &review_processes).await;
-    let pr_merge_state = infer_pr_merge_state(workspace, &latest_review_decision);
+    let pr_merge_state =
+        infer_pr_merge_state(deployment, workspace, &latest_review_decision).await?;
 
     if let Err(message) = auto_review_start_gate(
         workspace,
@@ -542,9 +563,9 @@ async fn start_review_fix_for_workspace(
 async fn advance_workspace_once(
     deployment: &DeploymentImpl,
     workspace: &Workspace,
-) -> Result<AutopilotAdvanceAction, ApiError> {
+) -> Result<(AutopilotAdvanceAction, Option<String>), ApiError> {
     let Some(_advance_guard) = WorkspaceAdvanceGuard::try_acquire(workspace.id) else {
-        return Ok(AutopilotAdvanceAction::Noop);
+        return Ok((AutopilotAdvanceAction::Noop, None));
     };
 
     let client = deployment.remote_client()?;
@@ -563,21 +584,29 @@ async fn advance_workspace_once(
             if let Some(issue) = issue.as_ref() {
                 promote_issue_to_in_review(&client, issue).await?;
             }
-            Ok(AutopilotAdvanceAction::StartedAutoReview)
+            Ok((AutopilotAdvanceAction::StartedAutoReview, None))
         }
         AutopilotNextAction::StartReviewFix => {
             start_review_fix_for_workspace(deployment, workspace).await?;
-            Ok(AutopilotAdvanceAction::StartedReviewFix)
+            Ok((AutopilotAdvanceAction::StartedReviewFix, None))
         }
-        AutopilotNextAction::ReadyForMerge => Ok(AutopilotAdvanceAction::MergeHandoff),
-        AutopilotNextAction::WaitForImplementation => Ok(AutopilotAdvanceAction::Noop),
+        AutopilotNextAction::ReadyForMerge => {
+            advance_merge_done_once(
+                deployment,
+                workspace,
+                issue.as_ref(),
+                &status.pr_merge_state,
+            )
+            .await
+        }
+        AutopilotNextAction::WaitForImplementation => Ok((AutopilotAdvanceAction::Noop, None)),
         AutopilotNextAction::NoWorkspace | AutopilotNextAction::InvestigateFailure => {
-            Ok(AutopilotAdvanceAction::Blocked)
+            Ok((AutopilotAdvanceAction::Blocked, status.blocker))
         }
         AutopilotNextAction::WaitForAutoReview
         | AutopilotNextAction::WaitForReviewFix
         | AutopilotNextAction::MergeWait
-        | AutopilotNextAction::Done => Ok(AutopilotAdvanceAction::Noop),
+        | AutopilotNextAction::Done => Ok((AutopilotAdvanceAction::Noop, None)),
     }
 }
 
@@ -604,6 +633,184 @@ impl Drop for WorkspaceAdvanceGuard {
             active.remove(&self.workspace_id);
         }
     }
+}
+
+async fn advance_merge_done_once(
+    deployment: &DeploymentImpl,
+    workspace: &Workspace,
+    issue: Option<&Issue>,
+    pr_merge_state: &str,
+) -> Result<(AutopilotAdvanceAction, Option<String>), ApiError> {
+    match merge_plan_from_state(pr_merge_state) {
+        AutopilotMergePlan::ReconcileDone => {
+            reconcile_workspace_done(deployment, workspace, issue).await?;
+            Ok((AutopilotAdvanceAction::Noop, None))
+        }
+        AutopilotMergePlan::Blocked(blocker) => {
+            Ok((AutopilotAdvanceAction::Blocked, Some(blocker)))
+        }
+        AutopilotMergePlan::AttemptPrMerge => {
+            match merge_single_open_pull_request(deployment, workspace).await {
+                Ok(()) => {
+                    reconcile_workspace_done(deployment, workspace, issue).await?;
+                    Ok((AutopilotAdvanceAction::Noop, None))
+                }
+                Err(blocker) => Ok((AutopilotAdvanceAction::Blocked, Some(blocker))),
+            }
+        }
+    }
+}
+
+fn merge_plan_from_state(pr_merge_state: &str) -> AutopilotMergePlan {
+    match pr_merge_state {
+        "merged_pending_done" => AutopilotMergePlan::ReconcileDone,
+        "pr_open_pending_merge" => AutopilotMergePlan::AttemptPrMerge,
+        "blocked_by_dirty_worktree" => AutopilotMergePlan::Blocked(
+            "Merge is blocked by dirty/conflicting workspace changes.".to_string(),
+        ),
+        "blocked_by_pr_requirements" => AutopilotMergePlan::Blocked(
+            "PR merge is blocked by GitHub checks, reviews, conflicts, or mergeability."
+                .to_string(),
+        ),
+        "no_pr_merge_found" => AutopilotMergePlan::Blocked(
+            "Review passed, but no open or merged pull request is linked to this workspace."
+                .to_string(),
+        ),
+        _ => AutopilotMergePlan::Blocked(
+            "Review passed, but merge state is not specific enough for the app to advance safely."
+                .to_string(),
+        ),
+    }
+}
+
+async fn merge_single_open_pull_request(
+    deployment: &DeploymentImpl,
+    workspace: &Workspace,
+) -> Result<(), String> {
+    let merges = Merge::find_by_workspace_id(&deployment.db().pool, workspace.id)
+        .await
+        .map_err(|err| format!("Failed to inspect linked pull requests: {err}"))?;
+    let open_prs = merges
+        .iter()
+        .filter_map(|merge| match merge {
+            Merge::Pr(pr) if matches!(pr.pr_info.status, MergeStatus::Open) => Some(pr),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let [open_pr] = open_prs.as_slice() else {
+        return Err(format!(
+            "Expected exactly one open pull request to merge, found {}.",
+            open_prs.len()
+        ));
+    };
+
+    let git_host = GitHostService::from_url(&open_pr.pr_info.url)
+        .map_err(|err| format!("Cannot identify pull request provider: {err}"))?;
+    let current_pr_info = git_host
+        .get_pr_status(&open_pr.pr_info.url)
+        .await
+        .map_err(|err| format!("Failed to refresh PR merge status from GitHub: {err}"))?;
+    if !matches!(
+        current_pr_info.status,
+        MergeStatus::Open | MergeStatus::Merged
+    ) {
+        persist_pr_status(deployment, workspace, open_pr, current_pr_info).await?;
+        return Err(
+            "Linked pull request is no longer open or mergeable; refreshed PR status and blocked auto-merge."
+                .to_string(),
+        );
+    }
+
+    let pr_info = if matches!(current_pr_info.status, MergeStatus::Merged) {
+        current_pr_info
+    } else {
+        let pr_info = git_host
+            .merge_pr(&open_pr.pr_info.url)
+            .await
+            .map_err(|err| format!("PR merge is blocked by GitHub requirements: {err}"))?;
+
+        if !matches!(pr_info.status, MergeStatus::Merged) {
+            persist_pr_status(deployment, workspace, open_pr, pr_info).await?;
+            return Err(
+                "GitHub accepted the merge command but the pull request is not merged yet."
+                    .to_string(),
+            );
+        }
+        pr_info
+    };
+
+    persist_pr_status(deployment, workspace, open_pr, pr_info)
+        .await
+        .map_err(|err| format!("PR merged but local/remote PR status update failed: {err}"))?;
+
+    Ok(())
+}
+
+async fn persist_pr_status(
+    deployment: &DeploymentImpl,
+    workspace: &Workspace,
+    open_pr: &PrMerge,
+    pr_detail: PullRequestDetail,
+) -> Result<(), String> {
+    let status = pr_detail.status.clone();
+    let merged_at = pr_detail.merged_at;
+    let merge_commit_sha = pr_detail.merge_commit_sha.clone();
+    let url = pr_detail.url.clone();
+
+    PullRequest::update_status(
+        &deployment.db().pool,
+        &url,
+        &status,
+        merged_at,
+        merge_commit_sha.clone(),
+    )
+    .await
+    .map_err(|err| format!("Local PR status update failed: {err}"))?;
+
+    if let Ok(client) = deployment.remote_client() {
+        let request = UpsertPullRequestRequest {
+            url,
+            number: pr_detail.number as i32,
+            status: pull_request_status_from_merge_status(&status),
+            merged_at,
+            merge_commit_sha,
+            target_branch_name: open_pr.target_branch_name.clone(),
+            local_workspace_id: workspace.id,
+        };
+        tokio::spawn(async move {
+            remote_sync::sync_pr_to_remote(&client, request).await;
+        });
+    }
+
+    Ok(())
+}
+
+fn pull_request_status_from_merge_status(status: &MergeStatus) -> PullRequestStatus {
+    match status {
+        MergeStatus::Merged => PullRequestStatus::Merged,
+        MergeStatus::Closed => PullRequestStatus::Closed,
+        MergeStatus::Open | MergeStatus::Unknown => PullRequestStatus::Open,
+    }
+}
+
+async fn reconcile_workspace_done(
+    deployment: &DeploymentImpl,
+    workspace: &Workspace,
+    issue: Option<&Issue>,
+) -> Result<(), ApiError> {
+    if let Some(issue) = issue {
+        move_issue_to_done(&deployment.remote_client()?, issue).await?;
+    }
+
+    if !workspace.pinned {
+        deployment
+            .container()
+            .archive_workspace(workspace.id)
+            .await?;
+    }
+
+    Ok(())
 }
 
 async fn build_autopilot_review_context(
@@ -732,6 +939,43 @@ async fn promote_issue_to_in_review(
     Ok(true)
 }
 
+async fn move_issue_to_done(client: &RemoteClient, issue: &Issue) -> Result<bool, ApiError> {
+    let statuses = client.list_project_statuses(issue.project_id).await?;
+    let Some(done) = statuses
+        .project_statuses
+        .iter()
+        .find(|status| status.name.trim().eq_ignore_ascii_case("done"))
+    else {
+        return Err(ApiError::Workspace(WorkspaceError::ValidationError(
+            "Cannot mark issue done because the project has no Done status.".to_string(),
+        )));
+    };
+
+    if issue.status_id == done.id && issue.completed_at.is_some() {
+        return Ok(false);
+    }
+
+    client
+        .update_issue(
+            issue.id,
+            &UpdateIssueRequest {
+                status_id: Some(done.id),
+                title: None,
+                description: None,
+                priority: None,
+                start_date: None,
+                target_date: None,
+                completed_at: Some(Some(Utc::now())),
+                sort_order: None,
+                parent_issue_id: None,
+                parent_issue_sort_order: None,
+                extension_metadata: None,
+            },
+        )
+        .await?;
+    Ok(true)
+}
+
 async fn build_status(
     deployment: &DeploymentImpl,
     workspace: &Workspace,
@@ -758,7 +1002,8 @@ async fn build_status(
         latest_review_decision.clone()
     };
     let review_fix_state = review_fix_state(review_fix_process);
-    let pr_merge_state = infer_pr_merge_state(workspace, &latest_review_decision);
+    let pr_merge_state =
+        infer_pr_merge_state(deployment, workspace, &latest_review_decision).await?;
     let (next_action, blocker) = next_action(
         workspace,
         implementation_process,
@@ -1179,17 +1424,90 @@ fn excerpt(text: &str) -> String {
     compact.chars().take(280).collect()
 }
 
-fn infer_pr_merge_state(workspace: &Workspace, decision: &AutopilotDecision) -> String {
+async fn infer_pr_merge_state(
+    deployment: &DeploymentImpl,
+    workspace: &Workspace,
+    decision: &AutopilotDecision,
+) -> Result<String, ApiError> {
     if workspace.archived || workspace.worktree_deleted {
-        return "done_or_archived".to_string();
+        return Ok("done_or_archived".to_string());
     }
-    match decision {
-        AutopilotDecision::Pass => "review_passed_merge_status_unknown".to_string(),
-        AutopilotDecision::RequestChanges => "blocked_by_review".to_string(),
-        AutopilotDecision::Running => "waiting_for_review".to_string(),
-        AutopilotDecision::Missing => "waiting_for_review".to_string(),
-        AutopilotDecision::Failed => "review_failed".to_string(),
+
+    if decision != &AutopilotDecision::Pass {
+        return Ok(match decision {
+            AutopilotDecision::RequestChanges => "blocked_by_review".to_string(),
+            AutopilotDecision::Running => "waiting_for_review".to_string(),
+            AutopilotDecision::Missing => "waiting_for_review".to_string(),
+            AutopilotDecision::Failed => "review_failed".to_string(),
+            AutopilotDecision::Pass => unreachable!(),
+        });
     }
+
+    let merges = Merge::find_by_workspace_id(&deployment.db().pool, workspace.id).await?;
+    let has_open_pr = merges.iter().any(
+        |merge| matches!(merge, Merge::Pr(pr) if matches!(pr.pr_info.status, MergeStatus::Open)),
+    );
+    let has_merged = merges.iter().any(|merge| match merge {
+        Merge::Direct(_) => true,
+        Merge::Pr(pr) => matches!(pr.pr_info.status, MergeStatus::Merged),
+    });
+
+    if has_open_pr {
+        if workspace_has_dirty_or_conflicting_changes(deployment, workspace).await? {
+            return Ok("blocked_by_dirty_worktree".to_string());
+        }
+        return Ok("pr_open_pending_merge".to_string());
+    }
+    if has_merged {
+        if workspace.pinned && linked_issue_is_done(deployment, workspace).await? {
+            return Ok("done_or_archived".to_string());
+        }
+        return Ok("merged_pending_done".to_string());
+    }
+
+    Ok("no_pr_merge_found".to_string())
+}
+
+async fn linked_issue_is_done(
+    deployment: &DeploymentImpl,
+    workspace: &Workspace,
+) -> Result<bool, ApiError> {
+    let client = deployment.remote_client()?;
+    let remote_workspace = client.get_workspace_by_local_id(workspace.id).await?;
+    let Some(issue_id) = remote_workspace.issue_id else {
+        return Ok(false);
+    };
+    let issue = client.get_issue(issue_id).await?;
+    Ok(issue.completed_at.is_some())
+}
+
+async fn workspace_has_dirty_or_conflicting_changes(
+    deployment: &DeploymentImpl,
+    workspace: &Workspace,
+) -> Result<bool, ApiError> {
+    let Some(container_ref) = workspace.container_ref.as_deref() else {
+        return Ok(false);
+    };
+    let workspace_path = PathBuf::from(container_ref);
+    let repos =
+        WorkspaceRepo::find_repos_for_workspace(&deployment.db().pool, workspace.id).await?;
+
+    for repo in repos {
+        let worktree_path = workspace_path.join(&repo.name);
+        let conflicted_files = deployment.git().get_conflicted_files(&worktree_path)?;
+        if !conflicted_files.is_empty() || deployment.git().is_rebase_in_progress(&worktree_path)? {
+            return Ok(true);
+        }
+
+        let (uncommitted_count, untracked_count) = deployment
+            .git()
+            .get_worktree_change_counts(&worktree_path)?;
+        if uncommitted_count > 0 || untracked_count > 0 {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 fn review_fix_start_gate(
@@ -1403,7 +1721,7 @@ fn workflow_state(
         AutopilotNextAction::ReadyForMerge => (
             AutopilotWorkflowState::ReviewPassed,
             blocker
-                .unwrap_or("Review passed; merge handoff is visible.")
+                .unwrap_or("Review passed; app advance owns merge/done reconciliation.")
                 .to_string(),
         ),
         AutopilotNextAction::MergeWait => (
@@ -1530,17 +1848,27 @@ fn next_action(
             ),
             _ => (AutopilotNextAction::StartReviewFix, None),
         },
-        // TODO(implication-autopilot): wire a safe PR merge helper here when the
-        // app can prove the PR is mergeable and checks/review requirements pass.
-        // The existing direct workspace merge helper intentionally rejects open
-        // PRs, so this state must remain an honest operator handoff for now.
-        AutopilotDecision::Pass => (
-            AutopilotNextAction::ReadyForMerge,
-            Some(
-                "Review passed; PR/check mergeability is not daemonized in this UI slice yet."
-                    .to_string(),
+        AutopilotDecision::Pass => match merge_plan_from_state(pr_merge_state) {
+            AutopilotMergePlan::Blocked(blocker)
+                if pr_merge_state == "blocked_by_dirty_worktree" =>
+            {
+                (AutopilotNextAction::InvestigateFailure, Some(blocker))
+            }
+            AutopilotMergePlan::Blocked(blocker) => {
+                (AutopilotNextAction::ReadyForMerge, Some(blocker))
+            }
+            AutopilotMergePlan::AttemptPrMerge => (
+                AutopilotNextAction::ReadyForMerge,
+                Some(
+                    "Review passed; app advance will attempt the linked PR merge and report GitHub blockers."
+                        .to_string(),
+                ),
             ),
-        ),
+            AutopilotMergePlan::ReconcileDone => (
+                AutopilotNextAction::ReadyForMerge,
+                Some("Review passed; app advance will reconcile merged PR state to Done.".to_string()),
+            ),
+        },
     }
 }
 
@@ -2160,7 +2488,7 @@ mod tests {
     }
 
     #[test]
-    fn next_action_surfaces_review_pass_as_ready_for_merge_but_not_automated() {
+    fn next_action_surfaces_review_pass_as_ready_for_app_merge() {
         let implementation = completed_process("Implementation", 0);
         let workspace = workspace();
         let (next_action, blocker) = next_action(
@@ -2169,11 +2497,63 @@ mod tests {
             &AutopilotDecision::Pass,
             None,
             None,
-            "review_passed_merge_status_unknown",
+            "pr_open_pending_merge",
         );
 
         assert_eq!(next_action, AutopilotNextAction::ReadyForMerge);
-        assert!(blocker.unwrap().contains("not daemonized"));
+        assert!(blocker.unwrap().contains("app advance"));
+    }
+
+    #[test]
+    fn merge_plan_reconciles_merged_pr_to_done_without_new_agent_session() {
+        let plan = merge_plan_from_state("merged_pending_done");
+
+        assert_eq!(plan, AutopilotMergePlan::ReconcileDone);
+    }
+
+    #[test]
+    fn done_or_archived_state_is_terminal_for_pinned_reconciliation() {
+        let implementation = completed_process("Implementation", 0);
+        let mut workspace = workspace();
+        workspace.pinned = true;
+        let (next_action, blocker) = next_action(
+            &workspace,
+            Some(&implementation),
+            &AutopilotDecision::Pass,
+            None,
+            None,
+            "done_or_archived",
+        );
+
+        assert_eq!(next_action, AutopilotNextAction::Done);
+        assert_eq!(blocker, None);
+    }
+
+    #[test]
+    fn next_action_blocks_dirty_or_conflicted_merge_state_after_review_pass() {
+        let implementation = completed_process("Implementation", 0);
+        let workspace = workspace();
+        let (next_action, blocker) = next_action(
+            &workspace,
+            Some(&implementation),
+            &AutopilotDecision::Pass,
+            None,
+            None,
+            "blocked_by_dirty_worktree",
+        );
+
+        assert_eq!(next_action, AutopilotNextAction::InvestigateFailure);
+        assert_eq!(
+            blocker,
+            Some("Merge is blocked by dirty/conflicting workspace changes.".to_string())
+        );
+        assert_eq!(
+            merge_plan_from_state("blocked_by_pr_requirements"),
+            AutopilotMergePlan::Blocked(
+                "PR merge is blocked by GitHub checks, reviews, conflicts, or mergeability."
+                    .to_string()
+            )
+        );
     }
 
     #[test]
@@ -2197,20 +2577,20 @@ mod tests {
     }
 
     #[test]
-    fn workflow_state_marks_review_pass_as_merge_handoff_without_token_use() {
+    fn workflow_state_marks_review_pass_as_app_owned_merge_without_token_use() {
         let implementation = completed_process("Implementation", 0);
         let (state, reason) = workflow_state(
             &AutopilotNextAction::ReadyForMerge,
-            Some("Review passed; merge handoff is visible."),
+            Some("Review passed; app advance owns merge/done reconciliation."),
             Some(&implementation),
             &AutopilotDecision::Pass,
             None,
             None,
-            "review_passed_merge_status_unknown",
+            "pr_open_pending_merge",
         );
 
         assert_eq!(state, AutopilotWorkflowState::ReviewPassed);
-        assert!(reason.contains("merge handoff"));
+        assert!(reason.contains("app advance"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds app/server-side Implication autopilot merge reconciliation so passed reviews can advance through merge, card Done movement, and evidence comments without a separate hidden operator watcher owning the terminal step.
- Extends git-host PR merge helpers so the server route can merge GitHub PRs from the app-owned autopilot path.
- Makes merge failures/reconciliation failures explicit and recoverable instead of silently leaving merged PRs or stuck review cards without visible evidence.

## Validation
- [x] `cargo fmt --check`
- [x] `cargo check -p server`
- [x] `cargo test -p server implication_autopilot::tests::linked_pr_completion --no-default-features`
- [x] `cargo test -p server implication_autopilot::tests --no-default-features`
- [x] Codex `gpt-5.5` / medium review after conflict resolution

## UI evidence
- N/A — server-side/app-owned workflow plumbing for autopilot merge reconciliation; visible UI status is consumed through the existing Implication autopilot panel.

## Runtime / Deploy Impact
- Changes local Vibe Kanban server behavior for Implication autopilot actions. No Implication runtime/model/data behavior changed.

## Migration / Data Impact
- No database migration. No data generation, labels, provenance, leakage risk, or evaluation comparability changes.

## Rollback Plan
- Revert this PR to return merge reconciliation to the previous non-app-owned/operator path.

