### PR TITLE
feat: include GitHub issue comments in Kanban startup context

### DIFF
--- a/crates/git-host/src/github/cli.rs
+++ b/crates/git-host/src/github/cli.rs
@@ -129,6 +129,16 @@ pub struct GitHubIssueSummary {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+pub struct GitHubIssueComment {
+    pub id: String,
+    pub author_login: Option<String>,
+    pub author_association: String,
+    pub body: String,
+    pub created_at: Option<DateTime<Utc>>,
+    pub url: String,
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct GhIssueResponse {
@@ -437,6 +447,56 @@ impl GhCli {
         Self::parse_issue(&raw, repo_full_name)
     }
 
+    pub fn get_issue_comments(
+        &self,
+        repo_full_name: &str,
+        issue_number: i64,
+        limit: usize,
+    ) -> Result<Vec<GitHubIssueComment>, GhCliError> {
+        let raw = self.run(
+            [
+                "issue",
+                "view",
+                &issue_number.to_string(),
+                "--repo",
+                repo_full_name,
+                "--json",
+                "comments",
+            ],
+            None,
+        )?;
+        let mut comments = Self::parse_issue_comments(&raw)?;
+        comments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        comments.truncate(limit.clamp(1, 25));
+        Ok(comments)
+    }
+
+    pub fn create_issue_comment(
+        &self,
+        repo_full_name: &str,
+        issue_number: i64,
+        body: &str,
+    ) -> Result<(), GhCliError> {
+        let mut body_file = NamedTempFile::new()
+            .map_err(|e| GhCliError::CommandFailed(format!("Failed to create temp file: {e}")))?;
+        body_file
+            .write_all(body.as_bytes())
+            .map_err(|e| GhCliError::CommandFailed(format!("Failed to write body: {e}")))?;
+
+        let args: Vec<OsString> = vec![
+            OsString::from("issue"),
+            OsString::from("comment"),
+            OsString::from(issue_number.to_string()),
+            OsString::from("--repo"),
+            OsString::from(repo_full_name),
+            OsString::from("--body-file"),
+            body_file.path().as_os_str().to_os_string(),
+        ];
+
+        self.run(args, None)?;
+        Ok(())
+    }
+
     /// Fetch comments for a pull request.
     pub fn get_pr_comments(
         &self,
@@ -614,6 +674,27 @@ impl GhCli {
         })?;
 
         Ok(Self::issue_response_to_summary(issue, repo_full_name))
+    }
+
+    fn parse_issue_comments(raw: &str) -> Result<Vec<GitHubIssueComment>, GhCliError> {
+        let wrapper: GhCommentsWrapper = serde_json::from_str(raw.trim()).map_err(|err| {
+            GhCliError::UnexpectedOutput(format!(
+                "Failed to parse gh issue comments response: {err}; raw: {raw}"
+            ))
+        })?;
+
+        Ok(wrapper
+            .comments
+            .into_iter()
+            .map(|comment| GitHubIssueComment {
+                id: comment.id,
+                author_login: comment.author.and_then(|author| author.login),
+                author_association: comment.author_association,
+                body: comment.body,
+                created_at: comment.created_at,
+                url: comment.url,
+            })
+            .collect())
     }
 
     fn issue_response_to_summary(

--- a/crates/git-host/src/github/mod.rs
+++ b/crates/git-host/src/github/mod.rs
@@ -7,7 +7,7 @@ use std::{path::Path, time::Duration};
 use async_trait::async_trait;
 use backon::{ExponentialBuilder, Retryable};
 use cli::GitHubRepoInfo;
-pub use cli::{GhCli, GhCliError, GitHubIssueSummary};
+pub use cli::{GhCli, GhCliError, GitHubIssueComment, GitHubIssueSummary};
 use tokio::task;
 use tracing::info;
 

--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -16,7 +16,7 @@ fn main() {
     }
 
     if let Ok(api_key) = std::env::var("POSTHOG_API_KEY") {
-        println!("cargo:rustc-env={}={}", "POSTHOG_API_KEY", api_key);
+        println!("cargo:rustc-env=POSTHOG_API_KEY={}", api_key);
     }
     if let Ok(api_endpoint) = std::env::var("POSTHOG_API_ENDPOINT") {
         println!("cargo:rustc-env=POSTHOG_API_ENDPOINT={}", api_endpoint);

--- a/crates/server/src/routes/github/issues.rs
+++ b/crates/server/src/routes/github/issues.rs
@@ -6,9 +6,9 @@ use axum::{
 };
 use git_host::{
     GitHostError,
-    github::{GhCli, GhCliError, GitHubIssueSummary},
+    github::{GhCli, GhCliError, GitHubIssueComment, GitHubIssueSummary},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::task;
 use url::Url;
 use utils::response::ApiResponse;
@@ -34,9 +34,24 @@ pub struct GitHubIssuePathParams {
     pub number: i64,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Serialize)]
 pub struct SearchGitHubIssuesResponse {
     pub issues: Vec<GitHubIssueSummary>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListGitHubIssueCommentsQuery {
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListGitHubIssueCommentsResponse {
+    pub comments: Vec<GitHubIssueComment>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateGitHubIssueCommentRequest {
+    pub body: String,
 }
 
 pub fn router() -> Router<DeploymentImpl> {
@@ -47,13 +62,17 @@ pub fn router() -> Router<DeploymentImpl> {
             "/github/issues/{owner}/{repo}/{number}",
             get(get_github_issue),
         )
+        .route(
+            "/github/issues/{owner}/{repo}/{number}/comments",
+            get(list_github_issue_comments).post(create_github_issue_comment),
+        )
 }
 
 pub async fn search_github_issues(
     State(_deployment): State<DeploymentImpl>,
     Query(query): Query<SearchGitHubIssuesQuery>,
 ) -> Result<ResponseJson<ApiResponse<SearchGitHubIssuesResponse>>, ApiError> {
-    let repo_full_name = normalize_repo_full_name(&query.repo)?;
+    let repo_full_name = normalize_repo_full_name(&query.repo).map_err(ApiError::BadRequest)?;
     let search_query = query.q.unwrap_or_default();
     let limit = query.limit.unwrap_or(20).clamp(1, 50);
 
@@ -69,7 +88,8 @@ pub async fn resolve_github_issue_url(
     State(_deployment): State<DeploymentImpl>,
     Json(payload): Json<ResolveGitHubIssueUrlRequest>,
 ) -> Result<ResponseJson<ApiResponse<GitHubIssueSummary>>, ApiError> {
-    let (repo_full_name, issue_number) = parse_issue_url(&payload.url)?;
+    let (repo_full_name, issue_number) =
+        parse_issue_url(&payload.url).map_err(ApiError::BadRequest)?;
     let issue = run_gh(move |cli| cli.get_issue(&repo_full_name, issue_number)).await?;
 
     Ok(ResponseJson(ApiResponse::success(issue)))
@@ -79,10 +99,42 @@ pub async fn get_github_issue(
     State(_deployment): State<DeploymentImpl>,
     Path(params): Path<GitHubIssuePathParams>,
 ) -> Result<ResponseJson<ApiResponse<GitHubIssueSummary>>, ApiError> {
-    let repo_full_name = normalize_repo_full_name(&format!("{}/{}", params.owner, params.repo))?;
+    let repo_full_name = normalize_repo_full_name(&format!("{}/{}", params.owner, params.repo))
+        .map_err(ApiError::BadRequest)?;
     let issue = run_gh(move |cli| cli.get_issue(&repo_full_name, params.number)).await?;
 
     Ok(ResponseJson(ApiResponse::success(issue)))
+}
+
+pub async fn list_github_issue_comments(
+    State(_deployment): State<DeploymentImpl>,
+    Path(params): Path<GitHubIssuePathParams>,
+    Query(query): Query<ListGitHubIssueCommentsQuery>,
+) -> Result<ResponseJson<ApiResponse<ListGitHubIssueCommentsResponse>>, ApiError> {
+    let repo_full_name = normalize_repo_full_name(&format!("{}/{}", params.owner, params.repo))
+        .map_err(ApiError::BadRequest)?;
+    let issue_number = params.number;
+    let limit = query.limit.unwrap_or(10).clamp(1, 25);
+    let comments =
+        run_gh(move |cli| cli.get_issue_comments(&repo_full_name, issue_number, limit)).await?;
+
+    Ok(ResponseJson(ApiResponse::success(
+        ListGitHubIssueCommentsResponse { comments },
+    )))
+}
+
+pub async fn create_github_issue_comment(
+    State(_deployment): State<DeploymentImpl>,
+    Path(params): Path<GitHubIssuePathParams>,
+    Json(payload): Json<CreateGitHubIssueCommentRequest>,
+) -> Result<ResponseJson<ApiResponse<()>>, ApiError> {
+    let repo_full_name = normalize_repo_full_name(&format!("{}/{}", params.owner, params.repo))
+        .map_err(ApiError::BadRequest)?;
+    let issue_number = params.number;
+    let body = format_kanban_update_comment(&payload.body).map_err(ApiError::BadRequest)?;
+    run_gh(move |cli| cli.create_issue_comment(&repo_full_name, issue_number, &body)).await?;
+
+    Ok(ResponseJson(ApiResponse::success(())))
 }
 
 async fn run_gh<T, F>(f: F) -> Result<T, ApiError>
@@ -101,7 +153,7 @@ where
     .map_err(|err| ApiError::BadGateway(format!("GitHub CLI task failed: {err}")))?
 }
 
-fn normalize_repo_full_name(repo: &str) -> Result<String, ApiError> {
+fn normalize_repo_full_name(repo: &str) -> Result<String, String> {
     let normalized = repo
         .trim()
         .trim_matches('/')
@@ -113,44 +165,66 @@ fn normalize_repo_full_name(repo: &str) -> Result<String, ApiError> {
     let repo_name = parts.next().unwrap_or_default();
 
     if owner.is_empty() || repo_name.is_empty() || parts.next().is_some() {
-        return Err(ApiError::BadRequest(
-            "Repository must be in owner/repo format".to_string(),
-        ));
+        return Err("Repository must be in owner/repo format".to_string());
     }
 
     Ok(format!("{owner}/{repo_name}"))
 }
 
-fn parse_issue_url(url: &str) -> Result<(String, i64), ApiError> {
-    let parsed = Url::parse(url)
-        .map_err(|_| ApiError::BadRequest("Invalid GitHub issue URL".to_string()))?;
+fn parse_issue_url(url: &str) -> Result<(String, i64), String> {
+    let parsed = Url::parse(url).map_err(|_| "Invalid GitHub issue URL".to_string())?;
 
     match parsed.host_str() {
         Some("github.com") | Some("www.github.com") => {}
         _ => {
-            return Err(ApiError::BadRequest(
-                "Only github.com issue URLs are supported".to_string(),
-            ));
+            return Err("Only github.com issue URLs are supported".to_string());
         }
     }
 
     let segments: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
     if segments.len() < 4 || segments[2] != "issues" {
-        return Err(ApiError::BadRequest(
-            "URL must point to a GitHub issue".to_string(),
-        ));
+        return Err("URL must point to a GitHub issue".to_string());
     }
 
     let repo_full_name = normalize_repo_full_name(&format!("{}/{}", segments[0], segments[1]))?;
-    let issue_number = segments[3].parse::<i64>().map_err(|_| {
-        ApiError::BadRequest("GitHub issue URL must include a numeric issue number".to_string())
-    })?;
+    let issue_number = segments[3]
+        .parse::<i64>()
+        .map_err(|_| "GitHub issue URL must include a numeric issue number".to_string())?;
 
     if issue_number <= 0 {
-        return Err(ApiError::BadRequest(
-            "GitHub issue number must be positive".to_string(),
-        ));
+        return Err("GitHub issue number must be positive".to_string());
     }
 
     Ok((repo_full_name, issue_number))
+}
+
+fn format_kanban_update_comment(body: &str) -> Result<String, String> {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return Err("Comment body must not be empty".to_string());
+    }
+
+    if trimmed.to_ascii_lowercase().starts_with("kanban update:") {
+        Ok(trimmed.to_string())
+    } else {
+        Ok(format!("Kanban update: {trimmed}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_kanban_update_comment;
+
+    #[test]
+    fn kanban_update_comment_prefix_is_enforced() {
+        assert_eq!(
+            format_kanban_update_comment("ready for review").unwrap(),
+            "Kanban update: ready for review"
+        );
+        assert_eq!(
+            format_kanban_update_comment("Kanban update: done with evidence").unwrap(),
+            "Kanban update: done with evidence"
+        );
+        assert!(format_kanban_update_comment("   ").is_err());
+    }
 }

--- a/crates/server/src/routes/implication_autopilot.rs
+++ b/crates/server/src/routes/implication_autopilot.rs
@@ -1333,18 +1333,19 @@ async fn list_processes(
 }
 
 fn process_summary(row: &ProcessRow) -> AutopilotProcessSummary {
-    process_summary_from_parts(
-        row.id,
-        row.session_id,
-        row.session_name.clone(),
-        row.status.clone(),
-        row.run_reason.clone(),
-        row.exit_code,
-        row.started_at.clone(),
-        row.completed_at.clone(),
-    )
+    AutopilotProcessSummary {
+        id: row.id,
+        session_id: row.session_id,
+        session_name: row.session_name.clone(),
+        status: row.status.clone(),
+        run_reason: row.run_reason.clone(),
+        exit_code: row.exit_code,
+        started_at: row.started_at.clone(),
+        completed_at: row.completed_at.clone(),
+    }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn process_summary_from_parts(
     id: Uuid,
     session_id: Uuid,
@@ -2080,6 +2081,7 @@ fn review_fix_start_gate(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn auto_review_start_gate(
     workspace: &Workspace,
     implementation: Option<&ProcessRow>,
@@ -2117,10 +2119,10 @@ fn auto_review_start_gate(
         }
     }
 
-    if let Some(blocker) = blocker {
-        if !rerun {
-            return Err(blocker);
-        }
+    if let Some(blocker) = blocker
+        && !rerun
+    {
+        return Err(blocker);
     }
 
     Ok(())

--- a/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
+++ b/packages/web-core/src/pages/kanban/IssueWorkspacesSectionContainer.tsx
@@ -9,7 +9,7 @@ import { useUserContext } from '@/shared/hooks/useUserContext';
 import { useWorkspaceContext } from '@/shared/hooks/useWorkspaceContext';
 import { useAppNavigation } from '@/shared/hooks/useAppNavigation';
 import { useProjectWorkspaceCreateDraft } from '@/shared/hooks/useProjectWorkspaceCreateDraft';
-import { workspacesApi, relayApi } from '@/shared/lib/api';
+import { githubIssuesApi, workspacesApi, relayApi } from '@/shared/lib/api';
 import { useHostId } from '@/shared/providers/HostIdProvider';
 import { getWorkspaceDefaults } from '@/shared/lib/workspaceDefaults';
 import {
@@ -151,10 +151,20 @@ export function IssueWorkspacesSectionContainer({
     }
 
     const issue = getIssue(issueId);
+    const githubLink = getGitHubIssueLink(issue?.extension_metadata);
+    const githubComments = githubLink
+      ? await githubIssuesApi
+          .listComments(githubLink.repo_full_name, githubLink.issue_number, {
+            hostId: currentHostId,
+            limit: 5,
+          })
+          .catch(() => [])
+      : [];
     const initialPrompt = buildWorkspaceCreatePrompt(
       issue?.title ?? null,
       issue?.description ?? null,
-      getGitHubIssueLink(issue?.extension_metadata)
+      githubLink,
+      githubComments
     );
     const localWorkspaceIds = buildLocalWorkspaceIdSet(
       activeWorkspaces,
@@ -194,6 +204,7 @@ export function IssueWorkspacesSectionContainer({
     activeWorkspaces,
     archivedWorkspaces,
     workspaces,
+    currentHostId,
     t,
   ]);
 

--- a/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
+++ b/packages/web-core/src/pages/kanban/KanbanIssuePanelContainer.tsx
@@ -1060,10 +1060,23 @@ export function KanbanIssuePanelContainer({
 
         if (displayData.createDraftWorkspace) {
           const githubLink = getGitHubIssueLink(syncedIssue.extension_metadata);
+          const githubComments = githubLink
+            ? await githubIssuesApi
+                .listComments(
+                  githubLink.repo_full_name,
+                  githubLink.issue_number,
+                  {
+                    hostId: effectiveHostId,
+                    limit: 5,
+                  }
+                )
+                .catch(() => [])
+            : [];
           const initialPrompt = buildWorkspaceCreatePrompt(
             displayData.title,
             displayData.description,
-            githubLink
+            githubLink,
+            githubComments
           );
 
           // Get defaults from most recent workspace
@@ -1131,6 +1144,7 @@ export function KanbanIssuePanelContainer({
     onExpectIssueOpen,
     t,
     kanbanCreateGitHubIssueLink,
+    effectiveHostId,
   ]);
 
   const handleCmdEnterSubmit = useCallback(() => {

--- a/packages/web-core/src/shared/dialogs/command-bar/WorkspaceSelectionDialog.tsx
+++ b/packages/web-core/src/shared/dialogs/command-bar/WorkspaceSelectionDialog.tsx
@@ -3,7 +3,7 @@ import { create, useModal } from '@ebay/nice-modal-react';
 import { useTranslation } from 'react-i18next';
 import { GitBranchIcon, PlusIcon } from '@phosphor-icons/react';
 import { defineModal } from '@/shared/lib/modals';
-import { ApiError, workspacesApi } from '@/shared/lib/api';
+import { ApiError, githubIssuesApi, workspacesApi } from '@/shared/lib/api';
 import { getWorkspaceDefaults } from '@/shared/lib/workspaceDefaults';
 import { ErrorDialog } from '@vibe/ui/components/ErrorDialog';
 import { useProjectWorkspaceCreateDraft } from '@/shared/hooks/useProjectWorkspaceCreateDraft';
@@ -168,10 +168,19 @@ function WorkspaceSelectionContent({
     try {
       // Get issue details for initial prompt
       const issue = getIssue(issueId);
+      const githubLink = getGitHubIssueLink(issue?.extension_metadata);
+      const githubComments = githubLink
+        ? await githubIssuesApi
+            .listComments(githubLink.repo_full_name, githubLink.issue_number, {
+              limit: 5,
+            })
+            .catch(() => [])
+        : [];
       const initialPrompt = buildWorkspaceCreatePrompt(
         issue?.title ?? null,
         issue?.description ?? null,
-        getGitHubIssueLink(issue?.extension_metadata)
+        githubLink,
+        githubComments
       );
 
       // Build set of local workspace IDs that exist on this machine

--- a/packages/web-core/src/shared/lib/api.ts
+++ b/packages/web-core/src/shared/lib/api.ts
@@ -105,7 +105,10 @@ import type { Project as RemoteProject } from 'shared/remote-types';
 import type { WorkspaceWithSession } from '@/shared/types/attempt';
 import { createWorkspaceWithSession } from '@/shared/types/attempt';
 import { resolveHostRequestScope } from '@/shared/lib/hostRequestScope';
-import type { GitHubIssueSummary } from '@/shared/lib/githubIssueLink';
+import type {
+  GitHubIssueComment,
+  GitHubIssueSummary,
+} from '@/shared/lib/githubIssueLink';
 import { makeRequest as makeRemoteRequest } from '@/shared/lib/remoteApi';
 import { makeLocalApiRequest } from '@/shared/lib/localApiTransport';
 
@@ -1895,6 +1898,10 @@ interface SearchGitHubIssuesResponse {
   issues: GitHubIssueSummary[];
 }
 
+interface ListGitHubIssueCommentsResponse {
+  comments: GitHubIssueComment[];
+}
+
 interface ResolveGitHubIssueUrlRequest {
   url: string;
 }
@@ -1949,6 +1956,44 @@ export const githubIssuesApi = {
       hostId
     );
     return handleApiResponse<GitHubIssueSummary>(response);
+  },
+
+  listComments: async (
+    repoFullName: string,
+    issueNumber: number,
+    opts?: { limit?: number; hostId?: string | null }
+  ): Promise<GitHubIssueComment[]> => {
+    const [owner, repo] = repoFullName.split('/');
+    const params = new URLSearchParams();
+    if (opts?.limit) {
+      params.set('limit', String(opts.limit));
+    }
+    const suffix = params.toString() ? `?${params.toString()}` : '';
+    const response = await makeHostAwareRequest(
+      `/api/github/issues/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${issueNumber}/comments${suffix}`,
+      opts?.hostId
+    );
+    const result =
+      await handleApiResponse<ListGitHubIssueCommentsResponse>(response);
+    return result.comments;
+  },
+
+  createKanbanUpdateComment: async (
+    repoFullName: string,
+    issueNumber: number,
+    body: string,
+    hostId?: string | null
+  ): Promise<void> => {
+    const [owner, repo] = repoFullName.split('/');
+    const response = await makeHostAwareRequest(
+      `/api/github/issues/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${issueNumber}/comments`,
+      hostId,
+      {
+        method: 'POST',
+        body: JSON.stringify({ body }),
+      }
+    );
+    await handleApiResponse<void>(response);
   },
 };
 

--- a/packages/web-core/src/shared/lib/githubIssueLink.ts
+++ b/packages/web-core/src/shared/lib/githubIssueLink.ts
@@ -24,6 +24,15 @@ export type GitHubIssueSummary = {
   updated_at?: string | null;
 };
 
+export type GitHubIssueComment = {
+  id: string;
+  author_login?: string | null;
+  author_association: string;
+  body: string;
+  created_at?: string | null;
+  url: string;
+};
+
 const GITHUB_LINK_KEY = 'github_link';
 
 function isJsonRecord(value: unknown): value is JsonRecord {

--- a/packages/web-core/src/shared/lib/workspaceCreateState.ts
+++ b/packages/web-core/src/shared/lib/workspaceCreateState.ts
@@ -4,7 +4,10 @@ import { ScratchType } from 'shared/types';
 import type { AppRuntime } from '@/shared/hooks/useAppRuntime';
 import { scratchApi } from '@/shared/lib/api';
 import { localStorageScratchUpdate } from '@/shared/hooks/useLocalStorageScratch';
-import type { GitHubIssueLink } from '@/shared/lib/githubIssueLink';
+import type {
+  GitHubIssueComment,
+  GitHubIssueLink,
+} from '@/shared/lib/githubIssueLink';
 
 interface WorkspaceDefaultsLike {
   preferredRepos?: CreateModeInitialState['preferredRepos'];
@@ -27,7 +30,8 @@ export const DEFAULT_WORKSPACE_CREATE_DRAFT_ID =
 export function buildWorkspaceCreatePrompt(
   title: string | null | undefined,
   description: string | null | undefined,
-  githubIssueLink?: GitHubIssueLink | null
+  githubIssueLink?: GitHubIssueLink | null,
+  githubIssueComments: GitHubIssueComment[] = []
 ): string | null {
   const trimmedTitle = title?.trim();
   if (!trimmedTitle) return null;
@@ -41,7 +45,41 @@ export function buildWorkspaceCreatePrompt(
     return basePrompt;
   }
 
-  return `${basePrompt}\n\n---\nLinked GitHub issue: ${githubIssueLink.repo_full_name}#${githubIssueLink.issue_number}\nIssue URL: ${githubIssueLink.issue_url}\nMaintain task progress visibility on that issue while you work.`;
+  const commentContext = formatGitHubIssueCommentContext(githubIssueComments);
+  const commentSection = commentContext
+    ? `\n\nRecent GitHub issue comments:\n${commentContext}`
+    : '';
+
+  return `${basePrompt}\n\n---\nLinked GitHub issue: ${githubIssueLink.repo_full_name}#${githubIssueLink.issue_number}\nIssue URL: ${githubIssueLink.issue_url}${commentSection}\nMaintain task progress visibility on that issue while you work.`;
+}
+
+export function formatGitHubIssueCommentContext(
+  comments: GitHubIssueComment[],
+  limit = 5
+): string {
+  return comments
+    .slice(0, limit)
+    .filter((comment) => comment.body.trim().length > 0)
+    .map((comment) => {
+      const author = comment.author_login
+        ? `@${comment.author_login}`
+        : 'unknown author';
+      const createdAt = comment.created_at ?? 'unknown time';
+      const body = truncateGitHubIssueComment(
+        comment.body.trim().replace(/\n{3,}/g, '\n\n')
+      );
+      return `- ${author} at ${createdAt}: ${body}`;
+    })
+    .filter((line) => line.trim().length > 0)
+    .join('\n');
+}
+
+function truncateGitHubIssueComment(body: string): string {
+  const maxLength = 1200;
+  if (body.length <= maxLength) {
+    return body;
+  }
+  return `${body.slice(0, maxLength).trimEnd()}\n[truncated]`;
 }
 
 export function buildLinkedIssueCreateState(


### PR DESCRIPTION
## Summary
- Adds GitHub issue comment list/write routes for linked issues, including enforced `Kanban update:` prefixing for write-back comments.
- Adds web-core API types/methods for listing issue comments and creating Kanban update comments.
- Includes recent linked GitHub issue comments in workspace startup prompts from the issue panel, workspace section, and workspace selection dialog so agents see durable issue context before work starts.

## Validation
- [x] `pnpm --filter @vibe/web-core run format`
- [x] `pnpm --filter @vibe/web-core run check`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] `scripts/run-rust-with-bindgen-env.sh cargo check -p server`
- [x] `CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 scripts/run-rust-with-bindgen-env.sh cargo test -p server routes::github::issues::tests::kanban_update_comment_prefix_is_enforced --lib --no-default-features`

## Implication Issue
- Advances gavinanelson/implication#171, specifically the existing-comment context and durable `Kanban update:` comment write-back acceptance criteria.

## Runtime / Deploy Impact
- Changes local Vibe Kanban server API and workspace-create prompt construction. No Implication runtime/model/data behavior changed.

## Migration / Data Impact
- No database migration. GitHub comments are fetched on demand and included in generated workspace startup context.

## Rollback Plan
- Revert this PR to remove the GitHub issue comment API additions and prompt enrichment.
