### PR TITLE
feat: make execution process status readable

### DIFF
--- a/packages/ui/src/components/ProcessListItem.tsx
+++ b/packages/ui/src/components/ProcessListItem.tsx
@@ -11,6 +11,10 @@ interface ProcessListItemProps {
   runReason: string;
   status: string;
   startedAt: string;
+  completedAt?: string | null;
+  executorLabel?: string | null;
+  exitCode?: string | number | bigint | null;
+  resultSummary?: string | null;
   selected?: boolean;
   onClick?: () => void;
   className?: string;
@@ -51,19 +55,38 @@ function getRunReasonIcon(runReason: string): typeof TerminalIcon {
 function getStatusColor(status: string): string {
   switch (status) {
     case 'running':
-      return 'bg-info';
+      return 'bg-info/10 text-info';
     case 'completed':
-      return 'bg-success';
+      return 'bg-success/10 text-success';
     case 'failed':
-      return 'bg-destructive';
+      return 'bg-destructive/10 text-destructive';
     case 'killed':
-      return 'bg-low';
+      return 'bg-tertiary text-low';
     default:
-      return 'bg-low';
+      return 'bg-tertiary text-low';
   }
 }
 
-function formatRelativeElapsed(dateString: string): string {
+function getStatusLabel(status: string): string {
+  switch (status) {
+    case 'running':
+      return 'Running';
+    case 'completed':
+      return 'Completed';
+    case 'failed':
+      return 'Failed';
+    case 'killed':
+      return 'Killed';
+    default:
+      return status;
+  }
+}
+
+function formatRelativeElapsed(dateString: string | null | undefined): string {
+  if (!dateString) {
+    return '';
+  }
+
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) {
     return '';
@@ -86,6 +109,10 @@ export function ProcessListItem({
   runReason,
   status,
   startedAt,
+  completedAt,
+  executorLabel,
+  exitCode,
+  resultSummary,
   selected,
   onClick,
   className,
@@ -93,40 +120,61 @@ export function ProcessListItem({
   const IconComponent = getRunReasonIcon(runReason);
   const label = getRunReasonLabel(runReason);
   const statusColor = getStatusColor(status);
+  const statusLabel = getStatusLabel(status);
 
   const isRunning = status === 'running';
+  const elapsedLabel = formatRelativeElapsed(
+    isRunning ? startedAt : completedAt || startedAt
+  );
+  const exitLabel =
+    !isRunning && exitCode !== null && exitCode !== undefined
+      ? `exit ${String(exitCode)}`
+      : null;
+  const detailParts = [
+    executorLabel || null,
+    isRunning ? 'live' : exitLabel,
+    resultSummary || null,
+    elapsedLabel || null,
+  ].filter(Boolean);
 
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
-        'w-full h-[26px] flex items-center gap-half px-half rounded-sm text-left transition-colors',
+        'w-full min-h-11 flex items-center gap-2 px-half py-1 rounded-sm text-left transition-colors',
+        selected ? 'bg-tertiary' : 'hover:bg-tertiary/60',
         className
       )}
+      title={`${label}: ${statusLabel}${detailParts.length ? ` - ${detailParts.join(' - ')}` : ''}`}
     >
       <IconComponent
         className="size-icon-sm flex-shrink-0 text-low"
         weight="regular"
       />
-      {isRunning ? (
-        <RunningDots />
-      ) : (
-        <span
-          className={cn('size-dot rounded-full flex-shrink-0', statusColor)}
-          title={status}
-        />
-      )}
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2 min-w-0">
+          <span
+            className={cn(
+              'text-sm truncate',
+              selected ? 'text-high' : 'text-normal'
+            )}
+          >
+            {label}
+          </span>
+          {isRunning && <RunningDots />}
+        </span>
+        <span className="block text-xs text-low truncate">
+          {detailParts.join(' · ')}
+        </span>
+      </span>
       <span
         className={cn(
-          'text-sm truncate flex-1',
-          selected ? 'text-high' : 'text-normal'
+          'text-[11px] leading-5 h-5 px-1.5 rounded-sm uppercase tracking-normal flex-shrink-0',
+          statusColor
         )}
       >
-        {label}
-      </span>
-      <span className="text-xs text-low flex-shrink-0">
-        {formatRelativeElapsed(startedAt)}
+        {statusLabel}
       </span>
     </button>
   );

--- a/packages/web-core/src/pages/workspaces/ProcessListContainer.tsx
+++ b/packages/web-core/src/pages/workspaces/ProcessListContainer.tsx
@@ -1,15 +1,67 @@
 import { useEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQueries } from '@tanstack/react-query';
 import { useExecutionProcessesContext } from '@/shared/hooks/useExecutionProcessesContext';
 import { useLogsPanel } from '@/shared/hooks/useLogsPanel';
 import { ProcessListItem } from '@vibe/ui/components/ProcessListItem';
 import { InputField } from '@vibe/ui/components/InputField';
+import { executionProcessesApi } from '@/shared/lib/api';
+import { executorConfigFromAction } from '@/shared/lib/executor';
 import {
   CaretUpIcon,
   CaretDownIcon,
   TerminalIcon,
 } from '@phosphor-icons/react';
 import { cn } from '@/shared/lib/utils';
+import type { ExecutionProcess, ExecutionProcessRepoState } from 'shared/types';
+
+function formatExecutorLabel(process: ExecutionProcess): string | null {
+  const executorConfig = executorConfigFromAction(
+    process.executor_action ?? null
+  );
+
+  if (!executorConfig) {
+    return null;
+  }
+
+  return [executorConfig.executor, executorConfig.variant]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function formatRepoStateSummary(
+  states: ExecutionProcessRepoState[] | undefined,
+  isFetching: boolean
+): string | null {
+  if (isFetching) {
+    return 'checking changes';
+  }
+
+  if (!states?.length) {
+    return null;
+  }
+
+  const changedRepoCount = states.filter(
+    (state) => state.before_head_commit !== state.after_head_commit
+  ).length;
+  const commitCount = states.filter((state) => state.merge_commit).length;
+
+  if (changedRepoCount === 0 && commitCount === 0) {
+    return 'no repo changes';
+  }
+
+  const parts = [];
+  if (changedRepoCount > 0) {
+    parts.push(
+      `${changedRepoCount} repo ${changedRepoCount === 1 ? 'changed' : 'changes'}`
+    );
+  }
+  if (commitCount > 0) {
+    parts.push(`${commitCount} ${commitCount === 1 ? 'commit' : 'commits'}`);
+  }
+
+  return parts.join(' · ');
+}
 
 export function ProcessListContainer() {
   const {
@@ -41,6 +93,29 @@ export function ProcessListContainer() {
       );
     });
   }, [executionProcessesVisible]);
+
+  const repoStateQueries = useQueries({
+    queries: sortedProcesses.map((process) => ({
+      queryKey: ['executionProcessRepoStates', process.id],
+      queryFn: () => executionProcessesApi.getRepoStates(process.id),
+      enabled: process.status !== 'running',
+      staleTime: 30_000,
+    })),
+  });
+
+  const processSummariesById = useMemo(() => {
+    const summaries: Record<string, string | null> = {};
+
+    sortedProcesses.forEach((process, index) => {
+      const query = repoStateQueries[index];
+      summaries[process.id] = formatRepoStateSummary(
+        query?.data,
+        Boolean(query?.isFetching)
+      );
+    });
+
+    return summaries;
+  }, [sortedProcesses, repoStateQueries]);
 
   // Auto-select latest process if none selected (unless disabled)
   useEffect(() => {
@@ -155,6 +230,10 @@ export function ProcessListContainer() {
             runReason={process.run_reason}
             status={process.status}
             startedAt={process.started_at}
+            completedAt={process.completed_at}
+            executorLabel={formatExecutorLabel(process)}
+            exitCode={process.exit_code}
+            resultSummary={processSummariesById[process.id]}
             selected={process.id === selectedProcessId}
             onClick={() => handleSelectProcess(process.id)}
           />


### PR DESCRIPTION
## Summary
- Makes execution process rows readable at a glance with explicit Running/Completed/Failed/Killed labels instead of only a tiny status dot.
- Shows executor profile, live/exit-code state, relative activity time, and repo-change/commit summaries from the existing execution process repo-state API.
- Keeps the implementation in the Vibe Kanban UI surface for Implication issue gavinanelson/implication#175.

## Validation
- pnpm --filter @vibe/ui run format
- pnpm --filter @vibe/ui run check
- pnpm --filter @vibe/ui run lint
- pnpm --filter @vibe/web-core run format
- pnpm --filter @vibe/web-core run check

## Impact
Operators watching a workspace/session can now see the active executor and process state directly in the session process list. Completed runs surface whether repo heads changed and whether merge commits were recorded.

## Not run
- Browser/native screenshot smoke is intentionally not included in this pass because Playwright/browser work is parked; this PR uses focused frontend validation only.

## Rollback
Revert this PR to restore the previous compact process rows.